### PR TITLE
Fix Issue #108

### DIFF
--- a/src/CommunityToolkit.Datasync.Client/Offline/Operations/ExecutableOperation.cs
+++ b/src/CommunityToolkit.Datasync.Client/Offline/Operations/ExecutableOperation.cs
@@ -32,6 +32,15 @@ internal abstract class ExecutableOperation
 
         if (baseAddress != null)
         {
+            if (baseAddress is { IsAbsoluteUri: true, Segments.Length: > 1 })
+            {
+                relativeOrAbsoluteUri = new Uri(relativeOrAbsoluteUri.ToString().TrimStart('/'), UriKind.Relative);
+                if (baseAddress.ToString()[^1] != '/')
+                {
+                    baseAddress = new Uri($"{baseAddress}/");
+                }
+            }
+
             if (baseAddress.IsAbsoluteUri)
             {
                 return new Uri($"{new Uri(baseAddress, relativeOrAbsoluteUri).ToString().TrimEnd('/')}/");

--- a/src/CommunityToolkit.Datasync.Client/Service/DatasyncServiceClient.cs
+++ b/src/CommunityToolkit.Datasync.Client/Service/DatasyncServiceClient.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using CommunityToolkit.Datasync.Client.Http;
+using CommunityToolkit.Datasync.Client.Offline.Operations;
 using CommunityToolkit.Datasync.Client.Paging;
 using CommunityToolkit.Datasync.Client.Query;
 using CommunityToolkit.Datasync.Client.Query.Linq;
@@ -146,7 +147,7 @@ public class DatasyncServiceClient<TEntity> : IDatasyncServiceClient<TEntity> wh
         ArgumentNullException.ThrowIfNull(query);
         ArgumentNullException.ThrowIfNull(options);
         QueryDescription queryDescription = new QueryTranslator<TEntity>(query).Translate();
-        
+
         // Make our query as efficient as possible for the specific task.
         queryDescription.Ordering.Clear();
         queryDescription.Selection.Clear();
@@ -183,7 +184,7 @@ public class DatasyncServiceClient<TEntity> : IDatasyncServiceClient<TEntity> wh
         {
             return result;
         }
-        
+
         result.ThrowIfNotSuccessful(requireContent: true);
         return result;
     }
@@ -529,19 +530,6 @@ public class DatasyncServiceClient<TEntity> : IDatasyncServiceClient<TEntity> wh
     /// <returns></returns>
     internal static Uri MakeAbsoluteUri(Uri? baseAddress, Uri relativeOrAbsoluteUri)
     {
-        if (relativeOrAbsoluteUri.IsAbsoluteUri)
-        {
-            return new Uri($"{relativeOrAbsoluteUri.ToString().TrimEnd('/')}/");
-        }
-
-        if (baseAddress != null)
-        {
-            if (baseAddress.IsAbsoluteUri)
-            {
-                return new Uri($"{new Uri(baseAddress, relativeOrAbsoluteUri).ToString().TrimEnd('/')}/");
-            }
-        }
-
-        throw new UriFormatException("Invalid combination of baseAddress and relativeUri");
+        return ExecutableOperation.MakeAbsoluteUri(baseAddress, relativeOrAbsoluteUri);
     }
 }

--- a/tests/CommunityToolkit.Datasync.Client.Test/Offline/DatasyncOfflineOptionsBuilder_Tests.cs
+++ b/tests/CommunityToolkit.Datasync.Client.Test/Offline/DatasyncOfflineOptionsBuilder_Tests.cs
@@ -29,7 +29,7 @@ public class DatasyncOfflineOptionsBuilder_Tests : BaseTest
 
     [Fact]
     public void UseHttpClientFactory_Null()
-    { 
+    {
         Type[] entityTypes = [typeof(ClientMovie), typeof(ClientKitchenSink)];
         DatasyncOfflineOptionsBuilder sut = new(entityTypes);
         Action act = () => _ = sut.UseHttpClientFactory(null);

--- a/tests/CommunityToolkit.Datasync.Client.Test/Offline/Operations/ExecutableOperation_Tests.cs
+++ b/tests/CommunityToolkit.Datasync.Client.Test/Offline/Operations/ExecutableOperation_Tests.cs
@@ -37,10 +37,10 @@ public class ExecutableOperation_Tests
     [InlineData("https://test.zumo.com", "/tables/movies/", "https://test.zumo.com/tables/movies/")]
     [InlineData("https://test.zumo.com/", "/tables/movies", "https://test.zumo.com/tables/movies/")]
     [InlineData("https://test.zumo.com/", "/tables/movies/", "https://test.zumo.com/tables/movies/")]
-    [InlineData("https://test.zumo.com/tables", "movies", "https://test.zumo.com/movies/")]
-    [InlineData("https://test.zumo.com/tables", "movies/", "https://test.zumo.com/movies/")]
-    [InlineData("https://test.zumo.com/tables", "/api/movies", "https://test.zumo.com/api/movies/")]
-    [InlineData("https://test.zumo.com/tables", "/api/movies/", "https://test.zumo.com/api/movies/")]
+    [InlineData("https://test.zumo.com/tables", "movies", "https://test.zumo.com/tables/movies/")]
+    [InlineData("https://test.zumo.com/tables", "movies/", "https://test.zumo.com/tables/movies/")]
+    [InlineData("https://test.zumo.com/tables", "/api/movies", "https://test.zumo.com/tables/api/movies/")]
+    [InlineData("https://test.zumo.com/tables", "/api/movies/", "https://test.zumo.com/tables/api/movies/")]
     public void MakeAbsoluteUri_Works(string ba, string bb, string expected)
     {
         Uri arg1 = string.IsNullOrEmpty(ba) ? null : new Uri(ba, UriKind.Absolute);

--- a/tests/CommunityToolkit.Datasync.Client.Test/Service/DatasyncServiceClient_Tests.cs
+++ b/tests/CommunityToolkit.Datasync.Client.Test/Service/DatasyncServiceClient_Tests.cs
@@ -1204,7 +1204,7 @@ public class DatasyncServiceClient_Tests : IDisposable
     [Fact]
     public async Task Query_TwoPagesOfItems()
     {
-        Page<ClientKitchenSink> 
+        Page<ClientKitchenSink>
             page1 = CreatePage(5, null, "$skip=5"),
             page2 = CreatePage(5);
 
@@ -3959,10 +3959,14 @@ public class DatasyncServiceClient_Tests : IDisposable
     [InlineData("https://test.zumo.com", "/tables/movies/", "https://test.zumo.com/tables/movies/")]
     [InlineData("https://test.zumo.com/", "/tables/movies", "https://test.zumo.com/tables/movies/")]
     [InlineData("https://test.zumo.com/", "/tables/movies/", "https://test.zumo.com/tables/movies/")]
-    [InlineData("https://test.zumo.com/tables", "movies", "https://test.zumo.com/movies/")]
-    [InlineData("https://test.zumo.com/tables", "movies/", "https://test.zumo.com/movies/")]
-    [InlineData("https://test.zumo.com/tables", "/api/movies", "https://test.zumo.com/api/movies/")]
-    [InlineData("https://test.zumo.com/tables", "/api/movies/", "https://test.zumo.com/api/movies/")]
+    //[InlineData("https://test.zumo.com/tables", "movies", "https://test.zumo.com/movies/")]
+    //[InlineData("https://test.zumo.com/tables", "movies/", "https://test.zumo.com/movies/")]
+    //[InlineData("https://test.zumo.com/tables", "/api/movies", "https://test.zumo.com/api/movies/")]
+    //[InlineData("https://test.zumo.com/tables", "api/movies/", "https://test.zumo.com/api/movies/")]
+    [InlineData("https://test.zumo.com/childpath/", "api/movies/", "https://test.zumo.com/childpath/api/movies/")]
+    [InlineData("https://test.zumo.com/childpath", "api/movies/", "https://test.zumo.com/childpath/api/movies/")]
+    [InlineData("https://test.zumo.com/childpath/", "/api/movies/", "https://test.zumo.com/childpath/api/movies/")]
+    [InlineData("https://test.zumo.com/childpath", "/api/movies/", "https://test.zumo.com/childpath/api/movies/")]
     public void MakeAbsoluteUri_Works(string ba, string bb, string expected)
     {
         Uri arg1 = string.IsNullOrEmpty(ba) ? null : new Uri(ba, UriKind.Absolute);


### PR DESCRIPTION
Refactor URI handling and update tests

Updated `MakeAbsoluteUri` in `ExecutableOperation.cs` to handle multi-segment `baseAddress` and ensure proper URI formatting. Added `using` directive in `DatasyncServiceClient.cs` and refactored its `MakeAbsoluteUri` method to use the one from `ExecutableOperation`. Made minor formatting changes in several methods and test cases for readability. Updated `MakeAbsoluteUri_Works` test in `DatasyncServiceClient_Tests.cs` with new scenarios.