### PR TITLE
(#135) Made DatasyncSerializer public.

### DIFF
--- a/src/CommunityToolkit.Datasync.Client/Serialization/DatasyncSerializer.cs
+++ b/src/CommunityToolkit.Datasync.Client/Serialization/DatasyncSerializer.cs
@@ -8,15 +8,23 @@ using System.Text.Json.Serialization;
 
 namespace CommunityToolkit.Datasync.Client.Serialization;
 
-internal static class DatasyncSerializer
+/// <summary>
+/// The serialization settings for Datasync settings.
+/// </summary>
+public static class DatasyncSerializer
 {
     private readonly static Lazy<JsonSerializerOptions> _initializer = new(GetJsonSerializerOptions);
+    private static JsonSerializerOptions? _userSuppliedOptions;
 
     /// <summary>
     /// Accessor for the common <see cref="JsonSerializerOptions"/> to use for serializing and deserializing 
     /// content in the service.
     /// </summary>
-    internal static JsonSerializerOptions JsonSerializerOptions { get => _initializer.Value; }
+    public static JsonSerializerOptions JsonSerializerOptions
+    { 
+        get => _userSuppliedOptions ?? _initializer.Value;
+        set => _userSuppliedOptions = value;
+    }
 
     /// <summary>
     /// Serializes an object using the serializer options.
@@ -24,7 +32,7 @@ internal static class DatasyncSerializer
     /// <typeparam name="T">The type of the object.</typeparam>
     /// <param name="obj">The object.</param>
     /// <returns>The serialized version of the object.</returns>
-    internal static string Serialize<T>(T obj)
+    public static string Serialize<T>(T obj)
         => JsonSerializer.Serialize(obj, JsonSerializerOptions);
 
     /// <summary>
@@ -33,7 +41,7 @@ internal static class DatasyncSerializer
     /// <param name="obj">The object.</param>
     /// <param name="objType">The type of the object.</param>
     /// <returns>The serialized version of the object.</returns>
-    internal static string Serialize(object obj, Type objType)
+    public static string Serialize(object obj, Type objType)
         => JsonSerializer.Serialize(obj, objType, JsonSerializerOptions);
 
     /// <summary>
@@ -41,7 +49,7 @@ internal static class DatasyncSerializer
     /// content in the service.  You should never have to call this.
     /// </summary>
     /// <returns>A configured <see cref="JsonSerializerOptions"/> object.</returns>
-    internal static JsonSerializerOptions GetJsonSerializerOptions() => new(JsonSerializerDefaults.Web)
+    public static JsonSerializerOptions GetJsonSerializerOptions() => new(JsonSerializerDefaults.Web)
     {
         AllowTrailingCommas = true,
         Converters =

--- a/tests/CommunityToolkit.Datasync.Client.Test/Authentication/GenericAuthenticationProvider_Tests.cs
+++ b/tests/CommunityToolkit.Datasync.Client.Test/Authentication/GenericAuthenticationProvider_Tests.cs
@@ -68,7 +68,6 @@ public class GenericAuthenticationProvider_Tests
     [InlineData(" ")]
     [InlineData("\t")]
     [InlineData(" \t ")]
-    [Trait("Method", "Ctor")]
     public void Ctor_Authorization_RequiresType(string authType)
     {
         Action act = () => _ = new GenericAuthenticationProvider(_ => Task.FromResult(ValidAuthenticationToken), "Authorization", authType);

--- a/tests/CommunityToolkit.Datasync.Client.Test/Serialization/DatasyncSerializer_Tests.cs
+++ b/tests/CommunityToolkit.Datasync.Client.Test/Serialization/DatasyncSerializer_Tests.cs
@@ -4,7 +4,7 @@
 
 using CommunityToolkit.Datasync.Client.Serialization;
 using CommunityToolkit.Datasync.TestCommon.Databases;
-
+using System.Text.Json;
 using TestData = CommunityToolkit.Datasync.TestCommon.TestData;
 
 namespace CommunityToolkit.Datasync.Client.Test.Serialization;
@@ -30,5 +30,19 @@ public class DatasyncSerializer_Tests
 
         actual = DatasyncSerializer.Serialize(movie, typeof(ClientMovie));
         actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public void CanSetSerializerOptions()
+    {
+        JsonSerializerOptions options = new(JsonSerializerDefaults.Web);
+        JsonSerializerOptions sut = DatasyncSerializer.JsonSerializerOptions;
+        sut.Should().NotBeNull().And.NotBe(options);
+
+        DatasyncSerializer.JsonSerializerOptions = options;
+        DatasyncSerializer.JsonSerializerOptions.Should().Be(options);
+
+        DatasyncSerializer.JsonSerializerOptions = null;
+        DatasyncSerializer.JsonSerializerOptions.Should().Be(sut);
     }
 }


### PR DESCRIPTION
This makes the DatasyncSerializer public and allows the developer to set DatasyncSerializer.JsonSerializerOptions to whatever they want.  If it is not set, a default set of options that matches the server expectations is used.  

This *SHOULD* only be needed for Native AOT.