### PR TITLE
(#171) PUT operation calls authorization with existing entity

### DIFF
--- a/src/CommunityToolkit.Datasync.Server/Controllers/TableController.Replace.cs
+++ b/src/CommunityToolkit.Datasync.Server/Controllers/TableController.Replace.cs
@@ -41,8 +41,7 @@ public partial class TableController<TEntity> : ODataController where TEntity : 
             throw new HttpException(StatusCodes.Status404NotFound);
         }
 
-        await AuthorizeRequestAsync(TableOperation.Update, entity, cancellationToken).ConfigureAwait(false);
-
+        await AuthorizeRequestAsync(TableOperation.Update, existing, cancellationToken).ConfigureAwait(false);
         if (Options.EnableSoftDelete && existing.Deleted && !Request.ShouldIncludeDeletedEntities())
         {
             Logger.LogWarning("ReplaceAsync: {id} statusCode=410 deleted", id);
@@ -50,11 +49,8 @@ public partial class TableController<TEntity> : ODataController where TEntity : 
         }
 
         Request.ParseConditionalRequest(existing, out byte[] version);
-
         await AccessControlProvider.PreCommitHookAsync(TableOperation.Update, entity, cancellationToken).ConfigureAwait(false);
-
         await Repository.ReplaceAsync(entity, version, cancellationToken).ConfigureAwait(false);
-
         await PostCommitHookAsync(TableOperation.Update, entity, cancellationToken).ConfigureAwait(false);
 
         Logger.LogInformation("ReplaceAsync: replaced {entity}", entity.ToJsonString());

--- a/tests/CommunityToolkit.Datasync.Server.Swashbuckle.Test/Swashbuckle_Tests.cs
+++ b/tests/CommunityToolkit.Datasync.Server.Swashbuckle.Test/Swashbuckle_Tests.cs
@@ -102,6 +102,7 @@ public class Swashbuckle_Tests
     {
         // Adjust this as necessary to the list of controllers in the TestService.
         string[] expected = [
+            "AuthorizedMovieController",
             "InMemoryKitchenSinkController",
             "InMemoryMovieController",
             "InMemoryPagedMovieController",

--- a/tests/CommunityToolkit.Datasync.Server.Test/Helpers/BaseTest.cs
+++ b/tests/CommunityToolkit.Datasync.Server.Test/Helpers/BaseTest.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using CommunityToolkit.Datasync.Common;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using NSubstitute;

--- a/tests/CommunityToolkit.Datasync.TestService/AccessControlProviders/MovieAccessControlProvider.cs
+++ b/tests/CommunityToolkit.Datasync.TestService/AccessControlProviders/MovieAccessControlProvider.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommunityToolkit.Datasync.Server;
+using CommunityToolkit.Datasync.TestCommon.Models;
+
+namespace CommunityToolkit.Datasync.TestService.AccessControlProviders;
+
+public class MovieAccessControlProvider<T> : AccessControlProvider<T> where T : class, IMovie, ITableData
+{
+    /// <summary>
+    /// The last entity that was authorized.
+    /// </summary>
+    public object LastEntity { get; private set; } = null;
+
+    /// <summary>
+    /// Determines if the entity can be authorized.
+    /// </summary>
+    public bool CanBeAuthorized { get; set; } = true;
+
+    /// <inheritdoc />
+    public override ValueTask<bool> IsAuthorizedAsync(TableOperation operation, T entity, CancellationToken cancellationToken = default)
+    {
+        LastEntity = entity;
+        return ValueTask.FromResult(CanBeAuthorized);
+    }
+}

--- a/tests/CommunityToolkit.Datasync.TestService/Controllers/AuthorizedMovieController.cs
+++ b/tests/CommunityToolkit.Datasync.TestService/Controllers/AuthorizedMovieController.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommunityToolkit.Datasync.Server;
+using CommunityToolkit.Datasync.TestCommon.Databases;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CommunityToolkit.Datasync.TestService.Controllers;
+
+[ExcludeFromCodeCoverage]
+[Route("api/authorized/movies")]
+public class AuthorizedMovieController : TableController<InMemoryMovie>
+{
+    public AuthorizedMovieController(IRepository<InMemoryMovie> repository, IAccessControlProvider<InMemoryMovie> provider) : base(repository)
+    {
+        AccessControlProvider = provider;
+    }
+}

--- a/tests/CommunityToolkit.Datasync.TestService/Program.cs
+++ b/tests/CommunityToolkit.Datasync.TestService/Program.cs
@@ -7,6 +7,7 @@ using CommunityToolkit.Datasync.Server.InMemory;
 using TestData = CommunityToolkit.Datasync.TestCommon.TestData;
 using CommunityToolkit.Datasync.TestCommon.Databases;
 using Microsoft.OData.ModelBuilder;
+using CommunityToolkit.Datasync.TestService.AccessControlProviders;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -21,6 +22,8 @@ modelBuilder.EnableLowerCamelCase();
 modelBuilder.AddEntityType(typeof(InMemoryMovie));
 modelBuilder.AddEntityType(typeof(InMemoryKitchenSink));
 builder.Services.AddDatasyncServices(modelBuilder.GetEdmModel());
+
+builder.Services.AddSingleton<IAccessControlProvider<InMemoryMovie>>(new MovieAccessControlProvider<InMemoryMovie>());
 
 builder.Services.AddControllers();
 


### PR DESCRIPTION
**BREAKING CHANGE**

- `PUT table/{id}` calls the access control provider with an existing entity rather than the (incomplete) new entity from the user.
- Added a modifiable access control provider and endpoint to test authorization providers in the test server.
- Test added to Replace_Tests.cs for using the access control provider.