### PR TITLE
#225 Add request body content to API operations

### DIFF
--- a/src/CommunityToolkit.Datasync.Server.Swashbuckle/DatasyncDocumentFilter.cs
+++ b/src/CommunityToolkit.Datasync.Server.Swashbuckle/DatasyncDocumentFilter.cs
@@ -112,6 +112,7 @@ public class DatasyncDocumentFilter(Assembly? assemblyToQuery = null) : IDocumen
                 case OpType.Create:
                     // Request Edits
                     operation.Value.AddConditionalHeader(true);
+                    operation.Value.AddRequestWithContent(context.SchemaRepository.Schemas[entityType.Name]);
 
                     // Response Edits
                     operation.Value.AddResponseWithContent("201", "Created", context.SchemaRepository.Schemas[entityType.Name]);
@@ -152,6 +153,7 @@ public class DatasyncDocumentFilter(Assembly? assemblyToQuery = null) : IDocumen
                 case OpType.Replace:
                     // Request Edits
                     operation.Value.AddConditionalHeader();
+                    operation.Value.AddRequestWithContent(context.SchemaRepository.Schemas[entityType.Name]);
 
                     // Response Edits
                     operation.Value.AddResponseWithContent("200", "OK", context.SchemaRepository.Schemas[entityType.Name]);

--- a/src/CommunityToolkit.Datasync.Server.Swashbuckle/DatasyncOperationExtensions.cs
+++ b/src/CommunityToolkit.Datasync.Server.Swashbuckle/DatasyncOperationExtensions.cs
@@ -95,6 +95,24 @@ internal static class DatasyncOperationExtensions
         });
         operation.Responses[statusCode] = response;
     }
+    /// <summary>
+    /// Adds the content type and schema to the request body.
+    /// </summary>
+    /// <param name="operation">The <see cref="OpenApiOperation"/> to modify.</param>
+    /// <param name="schema">The schema of the entity in the request.</param>
+    internal static void AddRequestWithContent(this OpenApiOperation operation, OpenApiSchema schema)
+    {
+        operation.RequestBody = new OpenApiRequestBody
+        {
+            Content = new Dictionary<string, OpenApiMediaType>
+            {
+                [JsonMediaType] = new OpenApiMediaType()
+                {
+                    Schema = schema
+                }
+            }
+        };
+    }
 
     /// <summary>
     /// Adds or replaces the 409/412 Conflict/Precondition Failed response.

--- a/tests/CommunityToolkit.Datasync.Server.Swashbuckle.Test/swagger.json
+++ b/tests/CommunityToolkit.Datasync.Server.Swashbuckle.Test/swagger.json
@@ -159,6 +159,15 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KitchenSink"
+              }
+            }
+          }
+        },
         "responses": {
           "201": {
             "description": "Created",
@@ -448,6 +457,15 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KitchenSink"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -530,6 +548,15 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TodoItem"
+              }
+            }
+          }
+        },
         "responses": {
           "201": {
             "description": "Created",
@@ -819,6 +846,15 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TodoItem"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",


### PR DESCRIPTION
Updated `ProcessController` in `DatasyncDocumentFilter.cs` to call `AddRequestWithContent` for `OpType.Create` and `OpType.Replace`. Added `AddRequestWithContent` method in `DatasyncOperationExtensions.cs` to modify `OpenApiOperation` with a request body schema. Updated `swagger.json` to include `requestBody` sections specifying `application/json` content type and appropriate schemas.