### PR TITLE
Fix LINQ conversion of `.Contains()`

### DIFF
--- a/tests/CommunityToolkit.Datasync.Client.Test/Query/IDatasyncPullQuery_Tests.cs
+++ b/tests/CommunityToolkit.Datasync.Client.Test/Query/IDatasyncPullQuery_Tests.cs
@@ -1177,7 +1177,7 @@ public class IDatasyncPullQuery_Tests
         );
     }
 
-    [Fact(Skip = "OData v8.4 does not allow string.contains")]
+    [Fact]
     public void Linq_Where_String_Contains()
     {
         string[] ratings = ["A", "B"];

--- a/tests/CommunityToolkit.Datasync.Client.Test/Query/IDatasyncQueryable_Tests.cs
+++ b/tests/CommunityToolkit.Datasync.Client.Test/Query/IDatasyncQueryable_Tests.cs
@@ -1416,7 +1416,7 @@ public class IDatasyncQueryable_Tests
         );
     }
 
-    [Fact(Skip = "OData v8.4 does not allow string.contains")]
+    [Fact]
     public void Linq_Where_String_Contains()
     {
         string[] ratings = ["A", "B"];

--- a/tests/CommunityToolkit.Datasync.Client.Test/Service/DatasyncServiceClient_Tests.cs
+++ b/tests/CommunityToolkit.Datasync.Client.Test/Service/DatasyncServiceClient_Tests.cs
@@ -3547,7 +3547,7 @@ public class DatasyncServiceClient_Tests : IDisposable
         );
     }
 
-    [Fact(Skip = "OData v8.4 does not allow string.contains")]
+    [Fact]
     public void Linq_Where_String_Contains()
     {
         string[] ratings = ["A", "B"];

--- a/tests/CommunityToolkit.Datasync.Client.Test/Service/Integration_Query_Tests.cs
+++ b/tests/CommunityToolkit.Datasync.Client.Test/Service/Integration_Query_Tests.cs
@@ -540,7 +540,7 @@ public class Integration_Query_Tests(ServiceApplicationFactory factory) : Servic
     //    );
     //}
 
-    [Fact(Skip = "OData v8.4 does not allow string.contains")]
+    [Fact]
     public async Task KitchenSinkQueryTest_020()
     {
         SeedKitchenSinkWithCountryData();


### PR DESCRIPTION
Closes #421: Fix LINQ conversion of `.Contains()` and re-enable tests.