### PR TITLE
fix: Upgrade of Automapper (#450)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <ODataVersion>8.4.3</ODataVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="AutoMapper" Version="16.0.0" />
+    <PackageVersion Include="AutoMapper" Version="16.1.1" />
     <PackageVersion Include="AwesomeAssertions" Version="9.3.0" />
     <PackageVersion Include="Azure.Identity" Version="1.17.1" />
     <PackageVersion Include="LiteDB" Version="5.0.21" />


### PR DESCRIPTION
Upgrades Automapper to v16.1.1 to remove risk of cascading recursion causing a SIGSEGV

Closes #450 