### PR TITLE
fix: resolve transitive package vulnerabilities and update dependencies (#460)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,20 +4,20 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <PropertyGroup>
-    <DotNetVersion>10.0.3</DotNetVersion>
-    <EFCoreVersion>10.0.3</EFCoreVersion>
-    <TestContainersVersion>4.10.0</TestContainersVersion>
+    <DotNetVersion>10.0.9</DotNetVersion>
+    <EFCoreVersion>10.0.9</EFCoreVersion>
+    <TestContainersVersion>4.12.0</TestContainersVersion>
     <ODataVersion>8.4.3</ODataVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AutoMapper" Version="16.1.1" />
-    <PackageVersion Include="AwesomeAssertions" Version="9.3.0" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="Azure.Identity" Version="1.17.1" />
     <PackageVersion Include="LiteDB" Version="5.0.21" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(DotNetVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.OData" Version="9.4.1" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="$(DotNetVersion)" />
-    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.57.0" />
+    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="$(EFCoreVersion)" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Cosmos" Version="$(EFCoreVersion)" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EFCoreVersion)" />
@@ -29,16 +29,16 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(DotNetVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="$(DotNetVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(DotNetVersion)" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Microsoft.OData.Core" Version="$(ODataVersion)" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.103" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="Microsoft.Spatial" Version="8.4.3" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.6.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.9.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="NSwag.AspNetCore" Version="14.6.3" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.0.1" />
+    <PackageVersion Include="NSwag.AspNetCore" Version="14.7.1" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.1" />
     <PackageVersion Include="System.Formats.Asn1" Version="$(DotNetVersion)" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
@@ -55,6 +55,6 @@
     <PackageVersion Include="Ulid" Version="1.4.1" />
     <!-- Do not change XUnit.Combinatorial to v2 (xUnit v2 compatibility) -->
     <PackageVersion Include="XUnit.Combinatorial" Version="1.6.24" />
-    <PackageVersion Include="XUnit.SkippableFact" Version="1.5.23" />
+    <PackageVersion Include="XUnit.SkippableFact" Version="1.5.61" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #460 

Resolves the SharpCompress (NU1902) and Snappier (NU1903) transitive vulnerabilities by bumping MongoDB.Driver (3.6.0 -> 3.9.0) and Testcontainers (4.10.0 -> 4.12.0), which now pull in SharpCompress 0.48.1 and Snappier 1.3.1. Also updates all other patch/minor dependencies.

Breaking (major) upgrades deferred to #465.