### PR TITLE
fix: hide conflicting record on create when not in IAccessControlProvider view (#445)

### DIFF
--- a/src/CommunityToolkit.Datasync.Server/Controllers/TableController.Create.cs
+++ b/src/CommunityToolkit.Datasync.Server/Controllers/TableController.Create.cs
@@ -32,7 +32,25 @@ public partial class TableController<TEntity> : ODataController where TEntity : 
 
         await AuthorizeRequestAsync(TableOperation.Create, entity, cancellationToken).ConfigureAwait(false);
         await AccessControlProvider.PreCommitHookAsync(TableOperation.Create, entity, cancellationToken).ConfigureAwait(false);
-        await Repository.CreateAsync(entity, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await Repository.CreateAsync(entity, cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpException ex) when (ex.StatusCode == StatusCodes.Status409Conflict && ex.Payload is TEntity conflictingEntity)
+        {
+            // A conflicting entity exists.  If the conflicting entity is not in the client's data view, then
+            // returning it (or even acknowledging the conflict) would leak data the client is not allowed to see.
+            // In that case, return a generic Bad Request without the payload instead.
+            if (!AccessControlProvider.EntityIsInView(conflictingEntity))
+            {
+                Logger.LogWarning("CreateAsync: {id} statusCode=400 conflicting entity not in view", entity.Id);
+                throw new HttpException(StatusCodes.Status400BadRequest);
+            }
+
+            throw;
+        }
+
         await PostCommitHookAsync(TableOperation.Create, entity, cancellationToken).ConfigureAwait(false);
 
         Logger.LogInformation("CreateAsync: created {id}", entity.Id);

--- a/tests/CommunityToolkit.Datasync.Server.Test/Controllers/TableController_Create_Tests.cs
+++ b/tests/CommunityToolkit.Datasync.Server.Test/Controllers/TableController_Create_Tests.cs
@@ -77,6 +77,38 @@ public class TableController_Create_Tests : BaseTest
     }
 
     [Fact]
+    public async Task CreateAsync_Conflict_EntityInView_Returns409()
+    {
+        TableData conflictingEntity = new() { Id = "0da7fb24-3606-442f-9f68-c47c6e7d09d4" };
+        // The data view includes the conflicting entity, so the conflict should be surfaced as a 409.
+        IAccessControlProvider<TableData> accessProvider = FakeAccessControlProvider<TableData>(TableOperation.Create, true, x => x.Id == conflictingEntity.Id);
+        IRepository<TableData> repository = FakeRepository<TableData>(null, true, conflictingEntity);
+        ExposedTableController<TableData> controller = new(repository, accessProvider);
+        TableData entity = new() { Id = conflictingEntity.Id };
+        controller.ControllerContext.HttpContext = CreateHttpContext(HttpMethod.Post, "https://localhost/table", entity);
+
+        Func<Task> act = async () => await controller.CreateAsync();
+
+        (await act.Should().ThrowAsync<HttpException>()).WithStatusCode(409);
+    }
+
+    [Fact]
+    public async Task CreateAsync_Conflict_EntityNotInView_Returns400()
+    {
+        TableData conflictingEntity = new() { Id = "0da7fb24-3606-442f-9f68-c47c6e7d09d4" };
+        // The data view excludes the conflicting entity, so the conflict must NOT be surfaced - return 400 instead.
+        IAccessControlProvider<TableData> accessProvider = FakeAccessControlProvider<TableData>(TableOperation.Create, true, x => x.Id == "some-other-id");
+        IRepository<TableData> repository = FakeRepository<TableData>(null, true, conflictingEntity);
+        ExposedTableController<TableData> controller = new(repository, accessProvider);
+        TableData entity = new() { Id = conflictingEntity.Id };
+        controller.ControllerContext.HttpContext = CreateHttpContext(HttpMethod.Post, "https://localhost/table", entity);
+
+        Func<Task> act = async () => await controller.CreateAsync();
+
+        (await act.Should().ThrowAsync<HttpException>()).WithStatusCode(400).And.Which.Payload.Should().BeNull();
+    }
+
+    [Fact]
     public async Task CreateAsync_NonJsonData_Throws()
     {
         IAccessControlProvider<TableData> accessProvider = FakeAccessControlProvider<TableData>(TableOperation.Create, true);

--- a/tests/CommunityToolkit.Datasync.Server.Test/Helpers/BaseTest.cs
+++ b/tests/CommunityToolkit.Datasync.Server.Test/Helpers/BaseTest.cs
@@ -32,15 +32,15 @@ public abstract class BaseTest
         return mock;
     }
 
-    protected static IRepository<TEntity> FakeRepository<TEntity>(TEntity entity = null, bool throwConflict = false) where TEntity : class, ITableData
+    protected static IRepository<TEntity> FakeRepository<TEntity>(TEntity entity = null, bool throwConflict = false, TEntity conflictPayload = null) where TEntity : class, ITableData
     {
         AbstractRepository<TEntity> mock = Substitute.ForPartsOf<AbstractRepository<TEntity>>();
 
         if (throwConflict)
         {
-            mock.CreateAsync(Arg.Any<TEntity>(), Arg.Any<CancellationToken>()).Returns(ValueTask.FromException(new HttpException(409)));
-            mock.DeleteAsync(Arg.Any<string>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>()).Returns(ValueTask.FromException(new HttpException(409)));
-            mock.ReplaceAsync(Arg.Any<TEntity>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>()).Returns(ValueTask.FromException(new HttpException(409)));
+            mock.CreateAsync(Arg.Any<TEntity>(), Arg.Any<CancellationToken>()).Returns(ValueTask.FromException(new HttpException(409) { Payload = conflictPayload }));
+            mock.DeleteAsync(Arg.Any<string>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>()).Returns(ValueTask.FromException(new HttpException(409) { Payload = conflictPayload }));
+            mock.ReplaceAsync(Arg.Any<TEntity>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>()).Returns(ValueTask.FromException(new HttpException(409) { Payload = conflictPayload }));
         }
         else
         {

--- a/tests/CommunityToolkit.Datasync.Server.Test/Helpers/ServiceApplicationFactory.cs
+++ b/tests/CommunityToolkit.Datasync.Server.Test/Helpers/ServiceApplicationFactory.cs
@@ -57,11 +57,12 @@ public class ServiceApplicationFactory : WebApplicationFactory<Program>
         return repository.GetEntity(id);
     }
 
-    internal void SetupAccessControlProvider(bool isAuthorized)
+    internal void SetupAccessControlProvider(bool isAuthorized, Expression<Func<InMemoryMovie, bool>> dataView = null)
     {
         using IServiceScope scope = Services.CreateScope();
         IAccessControlProvider<InMemoryMovie> provider = scope.ServiceProvider.GetRequiredService<IAccessControlProvider<InMemoryMovie>>();
         (provider as MovieAccessControlProvider<InMemoryMovie>).CanBeAuthorized = isAuthorized;
+        (provider as MovieAccessControlProvider<InMemoryMovie>).DataView = dataView;
     }
 
     internal InMemoryMovie GetAuthorizedEntity()

--- a/tests/CommunityToolkit.Datasync.Server.Test/Service/Create_Tests.cs
+++ b/tests/CommunityToolkit.Datasync.Server.Test/Service/Create_Tests.cs
@@ -69,6 +69,36 @@ public class Create_Tests(ServiceApplicationFactory factory) : ServiceTest(facto
     }
 
     [Fact]
+    public async Task Create_ExistingId_WithACP_InView_Returns409()
+    {
+        InMemoryMovie existingMovie = this.factory.GetRandomMovie();
+        // The data view INCLUDES the conflicting entity, so the conflict should be surfaced as a 409 with payload.
+        this.factory.SetupAccessControlProvider(true, m => m.Id == existingMovie.Id);
+        ClientMovie source = new(TestData.Movies.BlackPanther) { Id = existingMovie.Id };
+
+        HttpResponseMessage response = await this.client.PostAsJsonAsync(this.factory.AuthorizedMovieEndpoint, source, this.serializerOptions);
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+
+        ClientMovie clientMovie = await response.Content.ReadFromJsonAsync<ClientMovie>(this.serializerOptions);
+        clientMovie.Should().NotBeNull().And.HaveEquivalentMetadataTo(existingMovie).And.BeEquivalentTo<IMovie>(existingMovie);
+    }
+
+    [Fact]
+    public async Task Create_ExistingId_WithACP_NotInView_Returns400()
+    {
+        InMemoryMovie existingMovie = this.factory.GetRandomMovie();
+        // The data view EXCLUDES the conflicting entity, so the conflict must NOT be surfaced - return 400 with no payload.
+        this.factory.SetupAccessControlProvider(true, m => m.Id == "id-that-does-not-exist");
+        ClientMovie source = new(TestData.Movies.BlackPanther) { Id = existingMovie.Id };
+
+        HttpResponseMessage response = await this.client.PostAsJsonAsync(this.factory.AuthorizedMovieEndpoint, source, this.serializerOptions);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        string content = await response.Content.ReadAsStringAsync();
+        content.Should().NotContain(existingMovie.Id);
+    }
+
+    [Fact]
     public async Task Create_CanRoundtrip_Types()
     {
         const string id = "ks01";

--- a/tests/CommunityToolkit.Datasync.TestService/AccessControlProviders/MovieAccessControlProvider.cs
+++ b/tests/CommunityToolkit.Datasync.TestService/AccessControlProviders/MovieAccessControlProvider.cs
@@ -4,6 +4,7 @@
 
 using CommunityToolkit.Datasync.Server;
 using CommunityToolkit.Datasync.TestCommon.Models;
+using System.Linq.Expressions;
 
 namespace CommunityToolkit.Datasync.TestService.AccessControlProviders;
 
@@ -19,6 +20,15 @@ public class MovieAccessControlProvider<T> : AccessControlProvider<T> where T : 
     /// Determines if the entity can be authorized.
     /// </summary>
     public bool CanBeAuthorized { get; set; } = true;
+
+    /// <summary>
+    /// An optional data view filter that restricts which entities are visible to the client.
+    /// </summary>
+    public Expression<Func<T, bool>> DataView { get; set; } = null;
+
+    /// <inheritdoc />
+    public override Expression<Func<T, bool>> GetDataView()
+        => DataView;
 
     /// <inheritdoc />
     public override ValueTask<bool> IsAuthorizedAsync(TableOperation operation, T entity, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Closes #445 