### PR TITLE
docs: document secure UnsafeEntityLogging default in todoapp-mvc sample

### DIFF
--- a/samples/todoapp-mvc/TodoApp.Service/Controllers/TodoItemsController.cs
+++ b/samples/todoapp-mvc/TodoApp.Service/Controllers/TodoItemsController.cs
@@ -11,5 +11,10 @@ public class TodoItemsController : TableController<TodoItem>
     public TodoItemsController(TodoContext context) : base()
     {
         Repository = new EntityTableRepository<TodoItem>(context);
+
+        // UnsafeEntityLogging is intentionally left at its secure default (false).
+        // This sample stores user-supplied TodoItem content, so only the entity ID
+        // is logged; the full serialized entity is never written to the logs.
+        Options = new TableControllerOptions { UnsafeEntityLogging = false };
     }
 }

--- a/samples/todoapp-mvc/TodoApp.Service/TodoApp.Service.csproj
+++ b/samples/todoapp-mvc/TodoApp.Service/TodoApp.Service.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Datasync.Server" Version="10.0.0" />
-    <PackageReference Include="CommunityToolkit.Datasync.Server.EntityFrameworkCore" Version="10.0.0" />
+    <PackageReference Include="CommunityToolkit.Datasync.Server" Version="10.1.0" />
+    <PackageReference Include="CommunityToolkit.Datasync.Server.EntityFrameworkCore" Version="10.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" />
   </ItemGroup>


### PR DESCRIPTION
Closes #480

## Summary

Reviews the `samples/todoapp-mvc` server sample against v10.1.0's `UnsafeEntityLogging` option (#446).

- Bumps `CommunityToolkit.Datasync.Server` and `CommunityToolkit.Datasync.Server.EntityFrameworkCore` package references from 10.0.0 to 10.1.0, since the sample was still pinned to the release that predates `UnsafeEntityLogging`.
- Explicitly sets `UnsafeEntityLogging = false` in `TodoItemsController` with a comment documenting that this is the deliberate secure default — entity logging is intentionally left disabled so `TodoItem` contents are never written to the logs.

No behavior change: the sample already defaulted to `UnsafeEntityLogging = false` before this PR; the change only makes the default explicit and documented, and updates the package version so the sample actually builds against the option that introduced it.

## Testing

- `dotnet build samples/todoapp-mvc/part5.sln` — succeeds with 0 warnings / 0 errors.