### PR TITLE
docs: demonstrate UnsafeEntityLogging in todoapp-tutorial server walkthrough (#476)

### DIFF
--- a/samples/todoapp-tutorial/ServerApp/Controllers/TodoItemController.cs
+++ b/samples/todoapp-tutorial/ServerApp/Controllers/TodoItemController.cs
@@ -1,10 +1,23 @@
 using CommunityToolkit.Datasync.Server;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using ServerApp.Models;
 
 namespace ServerApp.Controllers;
 
 [Route("tables/todoitem")]
-public class TodoItemController(IRepository<TodoItem> repository) : TableController<TodoItem>(repository)
+public class TodoItemController : TableController<TodoItem>
 {
+    public TodoItemController(IRepository<TodoItem> repository, ILogger<TodoItemController> logger)
+        : base(repository)
+    {
+        Logger = logger;
+        Options = new TableControllerOptions
+        {
+            // Demonstrates entity serialization in the logs (entity ID at Information, full entity at Debug).
+            // Only enable when the additional diagnostic detail is required and the log sink is secured,
+            // as entity contents may contain PII, secrets, or other sensitive business data.
+            UnsafeEntityLogging = true
+        };
+    }
 }

--- a/samples/todoapp-tutorial/ServerApp/ServerApp.csproj
+++ b/samples/todoapp-tutorial/ServerApp/ServerApp.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Datasync.Server" Version="10.0.0" />
-    <PackageReference Include="CommunityToolkit.Datasync.Server.InMemory" Version="10.0.0" />
+    <PackageReference Include="CommunityToolkit.Datasync.Server" Version="10.1.0" />
+    <PackageReference Include="CommunityToolkit.Datasync.Server.InMemory" Version="10.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

v10.1.0 added the `UnsafeEntityLogging` option to `TableControllerOptions` (#446). `samples/todoapp-tutorial` is the main walkthrough referenced from `docs/tutorial/client/part-1.md` and `part-2.md` (`[todoapp]`), so this updates it to demonstrate the option by enabling sensitive entity logging, following the same pattern already used in the `todoapp-mvc` sample (#480 / #485, which demonstrated the secure `false` default).

## Changes

- `samples/todoapp-tutorial/ServerApp/ServerApp.csproj`: bump `CommunityToolkit.Datasync.Server` and `CommunityToolkit.Datasync.Server.InMemory` from `10.0.0` to `10.1.0` so the sample builds against the release that introduced `UnsafeEntityLogging`.
- `samples/todoapp-tutorial/ServerApp/Controllers/TodoItemController.cs`: replace the primary-constructor controller with an explicit constructor that wires an `ILogger<TodoItemController>` and sets `Options = new TableControllerOptions { UnsafeEntityLogging = true }`, with a comment explaining the security implication (entity contents may contain PII, secrets, or other sensitive business data; only enable when the log sink is secured).

## Acceptance criteria

- [x] `samples/todoapp-tutorial/ServerApp` enables `UnsafeEntityLogging = true` and wires an `ILogger`.
- [x] A code comment explains the security implication of enabling the option.
- [x] The sample builds against v10.1.0.

## Verification

- `dotnet restore` + `dotnet build` on `samples/todoapp-tutorial/ServerApp/ServerApp.csproj` — succeeded, 0 warnings/errors.
- `dotnet restore`/`dotnet build` on `Datasync.Toolkit.sln` — succeeded (pre-existing, unrelated `NU1903` advisories only; the sample is not part of this solution and is unaffected).

Closes #476