### PR TITLE
docs: document secure UnsafeEntityLogging default in datasync-server sample (#477)

### DIFF
--- a/samples/datasync-server/src/Sample.Datasync.Server/Controllers/TodoItemController.cs
+++ b/samples/datasync-server/src/Sample.Datasync.Server/Controllers/TodoItemController.cs
@@ -16,5 +16,9 @@ public class TodoItemController : TableController<TodoItem>
     public TodoItemController(AppDbContext context) 
         : base(new EntityTableRepository<TodoItem>(context))
     {
+        // UnsafeEntityLogging is intentionally left at its secure default (false).
+        // This sample stores user-supplied TodoItem content (Title), so only the
+        // entity ID is logged; the full serialized entity is never written to the logs.
+        Options = new TableControllerOptions { UnsafeEntityLogging = false };
     }
 }

--- a/samples/datasync-server/src/Sample.Datasync.Server/Controllers/TodoListController.cs
+++ b/samples/datasync-server/src/Sample.Datasync.Server/Controllers/TodoListController.cs
@@ -15,6 +15,9 @@ public class TodoListController : TableController<TodoList>
 {
     public TodoListController(AppDbContext context) : base(new EntityTableRepository<TodoList>(context))
     {
-        Options = new TableControllerOptions { EnableSoftDelete = true };
+        // UnsafeEntityLogging is intentionally left at its secure default (false).
+        // This sample stores user-supplied TodoList content (Title), so only the
+        // entity ID is logged; the full serialized entity is never written to the logs.
+        Options = new TableControllerOptions { EnableSoftDelete = true, UnsafeEntityLogging = false };
     }
 }

--- a/samples/datasync-server/src/Sample.Datasync.Server/Sample.Datasync.Server.csproj
+++ b/samples/datasync-server/src/Sample.Datasync.Server/Sample.Datasync.Server.csproj
@@ -7,12 +7,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.3">
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+
+    <!--
+      Microsoft.AspNetCore.OData (a transitive dependency via CommunityToolkit.Datasync.Server) floats
+      Microsoft.OData.Edm to a lower version than the one CommunityToolkit.Datasync.Server.Abstractions
+      already pins Microsoft.Spatial to. Pin it explicitly here to keep the resolved assembly versions
+      consistent, matching the src/Directory.Packages.props ODataVersion.
+    -->
+    <PackageReference Include="Microsoft.OData.Core" Version="8.4.3" />
+    <PackageReference Include="Microsoft.OData.Edm" Version="8.4.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Closes #477.

Reviews `samples/datasync-server/src/Sample.Datasync.Server` against the `UnsafeEntityLogging` option added in v10.1.0 (#446) and explicitly documents the secure default.

## Changes

- `Controllers/TodoItemController.cs`: previously had no `Options` configured (implicit default). Now explicitly sets `Options = new TableControllerOptions { UnsafeEntityLogging = false }` with a comment explaining that `TodoItem.Title` is user-supplied content, so the sample intentionally keeps entity logging disabled.
- `Controllers/TodoListController.cs`: already set `Options = new TableControllerOptions { EnableSoftDelete = true }`. Extended it with the same explicit `UnsafeEntityLogging = false` and comment, since `TodoList.Title` is also user-supplied content.
- `Sample.Datasync.Server.csproj`: bumped `Microsoft.AspNetCore.OpenApi`, `Microsoft.EntityFrameworkCore.SqlServer`, and `Microsoft.EntityFrameworkCore.Tools` from `10.0.3` to `10.0.9` to resolve a `NU1605` package-downgrade error that was breaking the sample build against the repo's currently centrally-managed dotnet 10 version (`DotNetVersion` in `Directory.Packages.props`). Resolving that surfaced a further `CS1705` assembly version conflict on `Microsoft.OData.Edm`/`Microsoft.OData.Core` (a transitive dependency via `Microsoft.AspNetCore.OData`), so those are now pinned to `8.4.3` as well, matching the `Microsoft.Spatial` pin already used by `CommunityToolkit.Datasync.Server.Abstractions` and the `ODataVersion` used in the root `Directory.Packages.props`. These build-fix changes were pre-existing and unrelated to `UnsafeEntityLogging`, but were needed to satisfy the issue's "sample builds and runs against v10.1.0" acceptance criterion.

This mirrors the pattern already used for the `todoapp-mvc` sample (#480/#485) and the `todoapp-tutorial` sample (#476/#487).

## Acceptance criteria

- [x] `UnsafeEntityLogging` remains `false` (default) in this sample.
- [x] A comment documents the deliberate secure default where `TableControllerOptions` is configured (both controllers).
- [x] The sample builds and runs against v10.1.0.

## Testing

- `dotnet build samples/datasync-server/src/Sample.Datasync.Server/Sample.Datasync.Server.csproj` — succeeds with 0 errors (previously failed with `NU1605`/`CS1705` before the version pins were added).
- `dotnet restore Datasync.Toolkit.sln` / `dotnet build Datasync.Toolkit.sln` — succeed with 0 errors.
- `dotnet test tests/CommunityToolkit.Datasync.Server.Test/CommunityToolkit.Datasync.Server.Test.csproj` — 2280 passed, 0 failed, 465 skipped (live/container-dependent tests, unaffected by this change).