### PR TITLE
docs: document secure UnsafeEntityLogging default in datasync-server-cosmosdb-singlecontainer sample (#478)

### DIFF
--- a/samples/datasync-server-cosmosdb-singlecontainer/src/Controllers/TodoItemController.cs
+++ b/samples/datasync-server-cosmosdb-singlecontainer/src/Controllers/TodoItemController.cs
@@ -14,5 +14,9 @@ public class TodoItemController : TableController<TodoItem>
     public TodoItemController(IRepository<TodoItem> repository) 
         : base(repository)
     {
+        // UnsafeEntityLogging is intentionally left at its secure default (false).
+        // This sample stores user-supplied TodoItem content (Title), so only the
+        // entity ID is logged; the full serialized entity is never written to the logs.
+        Options = new TableControllerOptions { UnsafeEntityLogging = false };
     }
 }

--- a/samples/datasync-server-cosmosdb-singlecontainer/src/Controllers/TodoListController.cs
+++ b/samples/datasync-server-cosmosdb-singlecontainer/src/Controllers/TodoListController.cs
@@ -13,6 +13,9 @@ public class TodoListController : TableController<TodoList>
 {
     public TodoListController(IRepository<TodoList> repository) : base(repository)
     {
-        Options = new TableControllerOptions { EnableSoftDelete = true };
+        // UnsafeEntityLogging is intentionally left at its secure default (false).
+        // This sample stores user-supplied TodoList content (Title), so only the
+        // entity ID is logged; the full serialized entity is never written to the logs.
+        Options = new TableControllerOptions { EnableSoftDelete = true, UnsafeEntityLogging = false };
     }
 }

--- a/samples/datasync-server-cosmosdb-singlecontainer/src/Sample.Datasync.Server.SingleContainer.csproj
+++ b/samples/datasync-server-cosmosdb-singlecontainer/src/Sample.Datasync.Server.SingleContainer.csproj
@@ -10,6 +10,15 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\CommunityToolkit.Datasync.Server.CosmosDb\CommunityToolkit.Datasync.Server.CosmosDb.csproj" />
     <ProjectReference Include="..\..\..\src\CommunityToolkit.Datasync.Server.Swashbuckle\CommunityToolkit.Datasync.Server.Swashbuckle.csproj" />
+
+    <!--
+      Microsoft.AspNetCore.OData (a transitive dependency via CommunityToolkit.Datasync.Server) floats
+      Microsoft.OData.Edm to a lower version than the one CommunityToolkit.Datasync.Server.Abstractions
+      already pins Microsoft.Spatial to. Pin it explicitly here to keep the resolved assembly versions
+      consistent, matching the src/Directory.Packages.props ODataVersion.
+    -->
+    <PackageReference Include="Microsoft.OData.Core" Version="8.4.3" />
+    <PackageReference Include="Microsoft.OData.Edm" Version="8.4.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Fixes #478.

v10.1.0 added the `UnsafeEntityLogging` option to `TableControllerOptions` (#446). When `false` (the default) only the entity ID is logged at `Information` level; when `true` the full serialized entity is logged at `Debug`.

This sample is not the docs-tutorial walkthrough, so it keeps the secure default (`UnsafeEntityLogging = false`). This PR documents that decision explicitly.

## Changes

- `Controllers/TodoItemController.cs`: explicitly set `UnsafeEntityLogging = false` with a comment explaining the sample keeps entity logging disabled to avoid writing `TodoItem` contents to logs.
- `Controllers/TodoListController.cs`: extended the existing `Options` initializer to add `UnsafeEntityLogging = false`, with the same comment style.
- `Sample.Datasync.Server.SingleContainer.csproj`: pinned `Microsoft.OData.Core`/`Microsoft.OData.Edm` to `8.4.3`. This was needed to fix a pre-existing `CS1705` assembly version conflict that prevented the sample from building — the same root cause and fix already applied to the sibling `datasync-server` sample (#477/#488): `samples/Directory.Packages.props` disables central package management, so this sample doesn't inherit the repo's central OData version pin.

## Acceptance criteria

- [x] `UnsafeEntityLogging` remains `false` (default) in this sample.
- [x] A comment documents the deliberate secure default where `TableControllerOptions` is configured.
- [x] The sample builds against v10.1.0 (verified via `dotnet build`; running requires a live/emulated Cosmos DB connection string, not available in this environment — see verification notes below).

## Verification

- `dotnet build samples/datasync-server-cosmosdb-singlecontainer/src/Sample.Datasync.Server.SingleContainer.csproj` → Build succeeded, 0 warnings, 0 errors.
- `dotnet build Datasync.Toolkit.sln` → Build succeeded, 0 errors (21 pre-existing NU1903 vulnerability warnings unrelated to this change, tracked separately in #489).
- `dotnet test Datasync.Toolkit.sln` → all 12 test projects passed, 0 failures (46,632 passed / 673 skipped across the suite; skips are pre-existing live/integration tests requiring external infra).
- Confirmed the OData build failure and its fix are pre-existing/unrelated to the controller changes by reproducing it on a clean stash of just the csproj change.
- No dedicated test project exists for this sample (consistent with sibling sample PRs #487/#488/#485).

Co-authored-by: ahall <ahall@cloudflare.com>