### PR TITLE
docs: document secure UnsafeEntityLogging default in todoapp-blazor-wasm sample (#479)

### DIFF
--- a/samples/todoapp-blazor-wasm/TodoApp.BlazorWasm.Server/Controllers/TodoItemsController.cs
+++ b/samples/todoapp-blazor-wasm/TodoApp.BlazorWasm.Server/Controllers/TodoItemsController.cs
@@ -70,5 +70,10 @@ public class TodoItemsController : TableController<TodoItem>
     public TodoItemsController(TodoContext context) : base()
     {
         Repository = new EntityTableRepository<TodoItem>(context);
+
+        // UnsafeEntityLogging is intentionally left at its secure default (false).
+        // This sample stores user-supplied TodoItem content (Title), so only the
+        // entity ID is logged; the full serialized entity is never written to the logs.
+        Options = new TableControllerOptions { UnsafeEntityLogging = false };
     }
 }

--- a/samples/todoapp-blazor-wasm/TodoApp.BlazorWasm.Server/TodoApp.BlazorWasm.Server.csproj
+++ b/samples/todoapp-blazor-wasm/TodoApp.BlazorWasm.Server/TodoApp.BlazorWasm.Server.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Datasync.Server" Version="10.0.0" />
-    <PackageReference Include="CommunityToolkit.Datasync.Server.EntityFrameworkCore" Version="10.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
+    <PackageReference Include="CommunityToolkit.Datasync.Server" Version="10.1.0" />
+    <PackageReference Include="CommunityToolkit.Datasync.Server.EntityFrameworkCore" Version="10.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Closes #479.

v10.1.0 added the `UnsafeEntityLogging` option to `TableControllerOptions` (#446). This sample is not the docs-tutorial walkthrough, so it should keep the secure default (`UnsafeEntityLogging = false`) rather than demonstrate the unsafe option.

## Changes

- `TodoItemsController` now explicitly sets `Options = new TableControllerOptions { UnsafeEntityLogging = false }` with a comment documenting that this is a deliberate choice to avoid writing `TodoItem` contents to the logs.
- Bumped `CommunityToolkit.Datasync.Server` / `CommunityToolkit.Datasync.Server.EntityFrameworkCore` to `10.1.0` (the release that introduced `UnsafeEntityLogging`), matching the version already used by the `todoapp-mvc` and `todoapp-tutorial` samples.
- Bumped `Microsoft.EntityFrameworkCore` / `Microsoft.EntityFrameworkCore.InMemory` to `10.0.9` to resolve a `NU1605` package downgrade error introduced by the Datasync EF Core package bump.

## Verification

- [x] `dotnet restore samples/todoapp-blazor-wasm/TodoApp.BlazorWasm.Server/TodoApp.BlazorWasm.Server.csproj`
- [x] `dotnet build samples/todoapp-blazor-wasm/TodoApp.BlazorWasm.Server/TodoApp.BlazorWasm.Server.csproj` — builds with 0 errors (pre-existing, unrelated `SQLitePCLRaw` NU1903 advisory warning only).

## Acceptance criteria

- [x] `UnsafeEntityLogging` remains `false` (default) in this sample.
- [x] The deliberate secure default is documented (comment + explicit `Options`).
- [x] The sample builds and runs against v10.1.0.