### PR TITLE
fix: resolve remaining sample package drift and Microsoft.OpenApi NU1903

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,6 +31,14 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(DotNetVersion)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Microsoft.OData.Core" Version="$(ODataVersion)" />
+    <!--
+      Microsoft.AspNetCore.OpenApi/NSwag.AspNetCore/Swashbuckle.AspNetCore all float a transitive
+      dependency on Microsoft.OpenApi 2.0.0, which has a known high-severity vulnerability (NU1903,
+      GHSA-v5pm-xwqc-g5wc - a crafted OpenAPI document with a circular schema reference can crash the
+      process). Pin explicitly to the patched 2.x release; CentralPackageTransitivePinningEnabled above
+      forces this version across all transitive references.
+    -->
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="Microsoft.Spatial" Version="8.4.3" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />

--- a/samples/todoapp-blazor-wasm/TodoApp.BlazorWasm.Client/TodoApp.BlazorWasm.Client.csproj
+++ b/samples/todoapp-blazor-wasm/TodoApp.BlazorWasm.Client/TodoApp.BlazorWasm.Client.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Datasync.Client" Version="10.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.3" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
+    <PackageReference Include="CommunityToolkit.Datasync.Client" Version="10.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/todoapp-blazor-wasm/TodoApp.BlazorWasm.Server/TodoApp.BlazorWasm.Server.csproj
+++ b/samples/todoapp-blazor-wasm/TodoApp.BlazorWasm.Server/TodoApp.BlazorWasm.Server.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="CommunityToolkit.Datasync.Server.EntityFrameworkCore" Version="10.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/todoapp-mvc/TodoApp.Service/TodoApp.Service.csproj
+++ b/samples/todoapp-mvc/TodoApp.Service/TodoApp.Service.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Datasync.Server" Version="10.1.0" />
     <PackageReference Include="CommunityToolkit.Datasync.Server.EntityFrameworkCore" Version="10.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" />
   </ItemGroup>
 

--- a/samples/todoapp-tutorial/ClientApp/ClientApp.csproj
+++ b/samples/todoapp-tutorial/ClientApp/ClientApp.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Datasync.Client" Version="10.0.0" />
+    <PackageReference Include="CommunityToolkit.Datasync.Client" Version="10.1.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
   </ItemGroup>
 

--- a/samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia/TodoApp.Avalonia.csproj
+++ b/samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia/TodoApp.Avalonia.csproj
@@ -16,8 +16,8 @@
         <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.0" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
         <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.0" />
-        <PackageReference Include="CommunityToolkit.Datasync.Client" Version="10.0.0" />
+        <PackageReference Include="CommunityToolkit.Datasync.Client" Version="10.1.0" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
     </ItemGroup>
 </Project>

--- a/samples/todoapp/TodoApp.MAUI/TodoApp.MAUI.csproj
+++ b/samples/todoapp/TodoApp.MAUI/TodoApp.MAUI.csproj
@@ -50,10 +50,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Datasync.Client" Version="10.0.0" />
+    <PackageReference Include="CommunityToolkit.Datasync.Client" Version="10.1.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.40" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/todoapp/TodoApp.Uno/Directory.Packages.props
+++ b/samples/todoapp/TodoApp.Uno/Directory.Packages.props
@@ -10,11 +10,11 @@
   <ItemGroup>
     <PackageVersion Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250402" />
     <PackageVersion Include="CommunityToolkit.WinUI.Converters" Version="8.2.250402" />
-    <PackageVersion Include="CommunityToolkit.Datasync.Client" Version="10.0.0" />
+    <PackageVersion Include="CommunityToolkit.Datasync.Client" Version="10.1.0" />
     <PackageVersion Include="Refit" Version="8.0.0" />
-    <PackageVersion Include="System.Formats.Asn1" Version="10.0.3" />
-    <PackageVersion Include="System.IO.Packaging" Version="10.0.3" />
+    <PackageVersion Include="System.Formats.Asn1" Version="10.0.9" />
+    <PackageVersion Include="System.IO.Packaging" Version="10.0.9" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.3" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.9" />
   </ItemGroup>
 </Project>

--- a/samples/todoapp/TodoApp.WPF/TodoApp.WPF.csproj
+++ b/samples/todoapp/TodoApp.WPF/TodoApp.WPF.csproj
@@ -10,6 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageReference Include="CommunityToolkit.Datasync.Client" Version="10.0.0" />
+    <PackageReference Include="CommunityToolkit.Datasync.Client" Version="10.1.0" />
   </ItemGroup>
 </Project>

--- a/samples/todoapp/TodoApp.WinUI3/TodoApp.WinUI3.csproj
+++ b/samples/todoapp/TodoApp.WinUI3/TodoApp.WinUI3.csproj
@@ -29,11 +29,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Datasync.Client" Version="10.0.0" />
+    <PackageReference Include="CommunityToolkit.Datasync.Client" Version="10.1.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="CommunityToolkit.WinUI.Behaviors" Version="8.2.250402" />
     <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.2.250402" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250401001" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.3916" />
     <Manifest Include="$(ApplicationManifest)" />


### PR DESCRIPTION
## Summary

Addresses the remaining unresolved items from #489 (the earlier sample fixes for `datasync-server`, `datasync-server-cosmosdb-singlecontainer`, and most of `todoapp-blazor-wasm`/`todoapp-mvc` were already merged in #488/#490/#491).

### Package version drift fixes

- `samples/todoapp-mvc`: `Microsoft.EntityFrameworkCore.SqlServer` `10.0.3 → 10.0.9` (missed in #485; same drift class as #488).
- `samples/todoapp-blazor-wasm`: stray `Microsoft.AspNetCore.Components.WebAssembly*` / `Microsoft.Extensions.Http` `10.0.3 → 10.0.9`.
- `samples/todoapp` client platforms (Avalonia, MAUI, WPF, WinUI3, Uno): `10.0.3 → 10.0.9` on `Microsoft.EntityFrameworkCore`, `Microsoft.Extensions.Logging.Debug`, `Microsoft.Extensions.DependencyInjection`, `System.Text.Json`/`Formats.Asn1`/`IO.Packaging`.
- `CommunityToolkit.Datasync.Client` `10.0.0 → 10.1.0` everywhere it's referenced (Avalonia, MAUI, Uno, WPF, WinUI3, `todoapp-blazor-wasm/Client`, `todoapp-tutorial/ClientApp`) to match the latest published package, bringing it in line with the server samples already on 10.1.0.

All values were checked against the root `Directory.Packages.props` (`DotNetVersion`/`EFCoreVersion` = `10.0.9`) and the latest published `CommunityToolkit.Datasync.*` NuGet versions.

### NU1903 — Microsoft.OpenApi (GHSA-v5pm-xwqc-g5wc)

Pinned `Microsoft.OpenApi` to the patched `2.7.5` release in root `Directory.Packages.props`. Because `CentralPackageTransitivePinningEnabled` is already `true` there, this propagates through `ProjectReference`s into `samples/datasync-server` and `samples/datasync-server-cosmosdb-singlecontainer` without needing a per-sample override — verified every `project.assets.json` in the repo now resolves `Microsoft.OpenApi/2.7.5`, with zero remaining `2.0.0` resolutions.

### NU1903 — SQLitePCLRaw.lib.e_sqlite3 (GHSA-2m69-gcr7-jv3q)

No patched version exists for this package (confirmed via the advisory and NuGet — the package is deprecated with no newer release). Filed #492 to track investigating this separately (potential suppression, migration off the EF Core Sqlite provider, or an alternate package) rather than bundling a bigger change into this PR.

### Not in scope for this PR

Per discussion on #489, a CI/script-based drift-prevention mechanism was intentionally **not** added here — this is a one-time cleanup pass, not an ask for ongoing automation.

## Verification

- `dotnet restore` / `dotnet build` / `dotnet test` on `Datasync.Toolkit.sln`: build succeeded, all test suites passed (Server, Client, EFCore, CosmosDb, MongoDB, LiteDb, InMemory, Automapper, NSwag, OpenApi, Swashbuckle test projects — 0 failures).
- Per-sample `dotnet restore` + `dotnet build` confirmed clean for: `todoapp-mvc`, `todoapp-blazor-wasm`, `datasync-server`, `datasync-server-cosmosdb-singlecontainer`, `todoapp-tutorial`, `TodoApp.Avalonia` (+ `.Desktop`), `TodoApp.WPF`.
- `TodoApp.MAUI`, `TodoApp.Uno` (mobile TFMs), and `TodoApp.WinUI3`'s full build could not be exercised on this (macOS, no Android/iOS/Windows workloads) machine, but `dotnet restore` got past all package-version resolution before hitting the workload-not-installed check, confirming the version pins themselves resolve cleanly.

## Related

- Closes #489
- Follow-up filed: #492 (SQLitePCLRaw.lib.e_sqlite3 NU1903 investigation)