### PR TITLE
build: enable NuGet trusted publishing for release workflows

### DIFF
--- a/.github/workflows/build-library.yml
+++ b/.github/workflows/build-library.yml
@@ -209,6 +209,9 @@ jobs:
     needs: [ sign ]
     environment: nuget-release-gate
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Setup .NET
@@ -222,10 +225,16 @@ jobs:
           name: nuget-signed
           path: ${{ github.workspace }}/packages
 
+      - name: NuGet login (OIDC)
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Push signed packages to NuGet.org
         run: >
           dotnet nuget push
           ${{ github.workspace }}/packages/**/*.nupkg
           --source https://api.nuget.org/v3/index.json
-          --api-key ${{ secrets.NUGET_PACKAGE_PUSH_TOKEN }}
+          --api-key ${{ steps.login.outputs.NUGET_API_KEY }}
           --skip-duplicate

--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -153,6 +153,9 @@ jobs:
     needs: [ sign ]
     environment: nuget-release-gate
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Setup .NET
@@ -166,10 +169,16 @@ jobs:
           name: nuget-signed
           path: ${{ github.workspace }}/packages
 
+      - name: NuGet login (OIDC)
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Push signed packages to NuGet.org
         run: >
           dotnet nuget push
           ${{ github.workspace }}/packages/**/*.nupkg
           --source https://api.nuget.org/v3/index.json
-          --api-key ${{ secrets.NUGET_PACKAGE_PUSH_TOKEN }}
+          --api-key ${{ steps.login.outputs.NUGET_API_KEY }}
           --skip-duplicate


### PR DESCRIPTION
Closes #486

## Summary

Switches the NuGet.org publish step in the `release` job of `build-library.yml` and `build-template.yml` from the long-lived `NUGET_PACKAGE_PUSH_TOKEN` API key secret to [NuGet Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing) via OIDC, matching the pattern already adopted in [CommunityToolkit/Aspire#1452](https://github.com/CommunityToolkit/Aspire/pull/1452).

- Added `permissions: { id-token: write, contents: read }` to the `release` job in both workflows (job-level `permissions` replace workflow-level ones, so these must be explicit).
- Added a `NuGet/login@v1` step (`NuGet login (OIDC)`) that exchanges the environment's `NUGET_USER` secret + OIDC token for a short-lived NuGet API key.
- Updated the `dotnet nuget push` step to use `${{ steps.login.outputs.NUGET_API_KEY }}` instead of `${{ secrets.NUGET_PACKAGE_PUSH_TOKEN }}`.

The `sign` job's push to the internal Azure DevOps feed (`DEVOPS_PACKAGE_PUSH_TOKEN`) is unrelated to nuget.org trusted publishing and is left unchanged.

Per the issue, the `nuget-release-gate` environment and `NUGET_USER` secret are already configured on GitHub, and both `build-library.yml` / `build-template.yml` are already registered as trusted publisher actions on nuget.org's policy.

## Tests and checks run

- No `src/`/`tests/` code changed, so `dotnet build`/`dotnet test` were not run — this is a CI-workflow-only change.
- Validated both modified YAML files parse correctly with Ruby's YAML library.
- Manually diffed against the reference implementation in CommunityToolkit/Aspire#1452 to confirm the pattern (permissions, login step, api-key output) matches.

## Skipped verification

- End-to-end trusted-publishing verification (an actual OIDC-authenticated push to nuget.org) can only happen on a real tagged release run in the `nuget-release-gate` environment; this isn't reproducible locally or in a PR run since the `release` job is gated on `startsWith(github.ref, 'refs/tags/')`.
- `actionlint`/`yamllint` are not installed in this environment, so only a generic YAML syntax check (not GitHub Actions schema validation) was performed locally.