### PR TITLE
fix: resolve NU1903 for Tmds.DBus.Protocol in Avalonia sample by bumping to 11.3.18

### DIFF
--- a/samples/todoapp/TodoApp.Avalonia/Directory.Build.props
+++ b/samples/todoapp/TodoApp.Avalonia/Directory.Build.props
@@ -1,6 +1,9 @@
 <Project>
   <PropertyGroup>
     <Nullable>enable</Nullable>
-    <AvaloniaVersion>11.2.3</AvaloniaVersion>
+    <!-- Keep in sync across all Avalonia.* PackageReferences in this sample tree. -->
+    <!-- Bumped to resolve NU1903 (GHSA-xrw6-gwf8-vvr9 / CVE-2026-39959) for Tmds.DBus.Protocol,
+         pulled in transitively via Avalonia.FreeDesktop -> Avalonia.Desktop. See #499. -->
+    <AvaloniaVersion>11.3.18</AvaloniaVersion>
   </PropertyGroup>
 </Project>

--- a/samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia.Android/TodoApp.Avalonia.Android.csproj
+++ b/samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia.Android/TodoApp.Avalonia.Android.csproj
@@ -18,7 +18,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia.Android" Version="11.3.0" />
+        <PackageReference Include="Avalonia.Android" Version="$(AvaloniaVersion)" />
         <PackageReference Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.15" />
     </ItemGroup>
 

--- a/samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia.Desktop/TodoApp.Avalonia.Desktop.csproj
+++ b/samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia.Desktop/TodoApp.Avalonia.Desktop.csproj
@@ -13,9 +13,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia.Desktop" Version="11.3.0" />
+        <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.0" />
+        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia.iOS/TodoApp.Avalonia.iOS.csproj
+++ b/samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia.iOS/TodoApp.Avalonia.iOS.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia.iOS" Version="11.3.0" />
+        <PackageReference Include="Avalonia.iOS" Version="$(AvaloniaVersion)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia/TodoApp.Avalonia.csproj
+++ b/samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia/TodoApp.Avalonia.csproj
@@ -11,11 +11,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.3.0" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.0" />
-        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.0" />
+        <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
+        <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.0" />
+        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
         <PackageReference Include="CommunityToolkit.Datasync.Client" Version="10.1.0" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />


### PR DESCRIPTION
## Summary

Resolves the Avalonia side of #499 (`NU1903` for `Tmds.DBus.Protocol`, pulled in transitively via `Avalonia.FreeDesktop` -> `Avalonia.Desktop`).

Confirmed via NuGet nuspec inspection that `Avalonia.FreeDesktop 11.3.18` (the latest 11.x patch) already bumps its `Tmds.DBus.Protocol` dependency to `0.21.3`, the patched version per [GHSA-xrw6-gwf8-vvr9](https://github.com/advisories/GHSA-xrw6-gwf8-vvr9) / CVE-2026-39959:

```
Avalonia.FreeDesktop/11.3.0  -> Tmds.DBus.Protocol 0.21.2  (vulnerable)
Avalonia.FreeDesktop/11.3.18 -> Tmds.DBus.Protocol 0.21.3  (patched)
```

No major-version bump or explicit `Tmds.DBus.Protocol` override is needed — a patch bump within Avalonia 11.x is sufficient.

## Changes

- Bumped the shared `AvaloniaVersion` property in `samples/todoapp/TodoApp.Avalonia/Directory.Build.props` from the stale/unused `11.2.3` to `11.3.18`.
- Wired up all 4 `TodoApp.Avalonia*` csproj files (`TodoApp.Avalonia`, `.Desktop`, `.Android`, `.iOS`) to consume `$(AvaloniaVersion)` instead of hardcoding `11.3.0` per project, so this stays in sync going forward.

## Validation

- `dotnet restore`/`dotnet build` on `TodoApp.Avalonia.Desktop.csproj` (Debug and Release) succeed with no `NU1903` warning.
- Verified in `project.assets.json` that `Tmds.DBus.Protocol` now resolves to `0.21.3` and `Avalonia.FreeDesktop` to `11.3.18`.
- Could not build/verify the Android or iOS heads in this environment (no `android`/`ios` `dotnet` workloads installed) — this is a patch-level version bump with no API surface changes, so risk is low, but flagging since `/samples` has no CI coverage today.

## Follow-ups filed

- #506 — equivalent `Tmds.DBus` NU1903 investigation for the Uno sample (split out from #499's original combined scope).
- #507 — separate, larger effort to bump the Avalonia sample to major version 12 (not required to close this issue).

Fixes #499
