### PR TITLE
ci: add build-samples workflow for Phase 1 low-workload samples

### DIFF
--- a/.github/workflows/build-samples-datasync-server-cosmosdb.yml
+++ b/.github/workflows/build-samples-datasync-server-cosmosdb.yml
@@ -1,0 +1,35 @@
+name: Build Sample - Datasync Server (Cosmos DB)
+
+on:
+  workflow_call:
+
+env:
+  DOTNET_VERSION: '10.0.x'
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+  DOTNET_CONFIGURATION: 'Release'
+  SolutionFile: 'samples/datasync-server-cosmosdb-singlecontainer/Datasync.Server.CosmosDb.SingleContainer.sln'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore dependencies
+        run: dotnet restore ${{ env.SolutionFile }}
+
+      - name: Build sample
+        run: >
+          dotnet build ${{ env.SolutionFile }}
+          --configuration ${{ env.DOTNET_CONFIGURATION }}
+          --no-restore

--- a/.github/workflows/build-samples-datasync-server.yml
+++ b/.github/workflows/build-samples-datasync-server.yml
@@ -1,0 +1,35 @@
+name: Build Sample - Datasync Server
+
+on:
+  workflow_call:
+
+env:
+  DOTNET_VERSION: '10.0.x'
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+  DOTNET_CONFIGURATION: 'Release'
+  SolutionFile: 'samples/datasync-server/Sample.Datasync.Server.sln'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore dependencies
+        run: dotnet restore ${{ env.SolutionFile }}
+
+      - name: Build sample
+        run: >
+          dotnet build ${{ env.SolutionFile }}
+          --configuration ${{ env.DOTNET_CONFIGURATION }}
+          --no-restore

--- a/.github/workflows/build-samples-todoapp-avalonia.yml
+++ b/.github/workflows/build-samples-todoapp-avalonia.yml
@@ -1,0 +1,49 @@
+name: Build Sample - TodoApp Avalonia
+
+on:
+  workflow_call:
+
+env:
+  DOTNET_VERSION: '10.0.x'
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+  DOTNET_CONFIGURATION: 'Release'
+  # NOTE: This sample's solution (TodoApp.Avalonia.sln) also contains Android and iOS
+  # heads (net10.0-android / net10.0-ios), which require mobile workloads and are tracked
+  # separately in https://github.com/CommunityToolkit/Datasync/issues/511 (Phase 3). Only
+  # the shared and Desktop (net10.0) projects are built directly here, not the full .sln.
+  SharedProjectFile: 'samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia/TodoApp.Avalonia.csproj'
+  DesktopProjectFile: 'samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia.Desktop/TodoApp.Avalonia.Desktop.csproj'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore shared project
+        run: dotnet restore ${{ env.SharedProjectFile }}
+
+      - name: Build shared project
+        run: >
+          dotnet build ${{ env.SharedProjectFile }}
+          --configuration ${{ env.DOTNET_CONFIGURATION }}
+          --no-restore
+
+      - name: Restore desktop project
+        run: dotnet restore ${{ env.DesktopProjectFile }}
+
+      - name: Build desktop project
+        run: >
+          dotnet build ${{ env.DesktopProjectFile }}
+          --configuration ${{ env.DOTNET_CONFIGURATION }}
+          --no-restore

--- a/.github/workflows/build-samples-todoapp-blazor-wasm.yml
+++ b/.github/workflows/build-samples-todoapp-blazor-wasm.yml
@@ -1,0 +1,35 @@
+name: Build Sample - TodoApp Blazor WASM
+
+on:
+  workflow_call:
+
+env:
+  DOTNET_VERSION: '10.0.x'
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+  DOTNET_CONFIGURATION: 'Release'
+  SolutionFile: 'samples/todoapp-blazor-wasm/TodoApp.BlazorWasm.sln'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore dependencies
+        run: dotnet restore ${{ env.SolutionFile }}
+
+      - name: Build sample
+        run: >
+          dotnet build ${{ env.SolutionFile }}
+          --configuration ${{ env.DOTNET_CONFIGURATION }}
+          --no-restore

--- a/.github/workflows/build-samples-todoapp-mvc.yml
+++ b/.github/workflows/build-samples-todoapp-mvc.yml
@@ -1,0 +1,35 @@
+name: Build Sample - TodoApp MVC
+
+on:
+  workflow_call:
+
+env:
+  DOTNET_VERSION: '10.0.x'
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+  DOTNET_CONFIGURATION: 'Release'
+  SolutionFile: 'samples/todoapp-mvc/part5.sln'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore dependencies
+        run: dotnet restore ${{ env.SolutionFile }}
+
+      - name: Build sample
+        run: >
+          dotnet build ${{ env.SolutionFile }}
+          --configuration ${{ env.DOTNET_CONFIGURATION }}
+          --no-restore

--- a/.github/workflows/build-samples-todoapp-tutorial.yml
+++ b/.github/workflows/build-samples-todoapp-tutorial.yml
@@ -1,0 +1,39 @@
+name: Build Sample - TodoApp Tutorial
+
+on:
+  workflow_call:
+
+env:
+  DOTNET_VERSION: '10.0.x'
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+  DOTNET_CONFIGURATION: 'Release'
+  # NOTE: This sample's solution (todoapp.sln) also contains ClientApp, a WPF project
+  # targeting net10.0-windows. That head requires a windows-latest runner and is tracked
+  # separately in https://github.com/CommunityToolkit/Datasync/issues/510 (Phase 2). Only
+  # ServerApp (net10.0) is built here.
+  ProjectFile: 'samples/todoapp-tutorial/ServerApp/ServerApp.csproj'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore dependencies
+        run: dotnet restore ${{ env.ProjectFile }}
+
+      - name: Build sample
+        run: >
+          dotnet build ${{ env.ProjectFile }}
+          --configuration ${{ env.DOTNET_CONFIGURATION }}
+          --no-restore

--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -1,0 +1,55 @@
+name: Build Samples
+
+on:
+  push:
+    branches: [ main ]
+    paths: [ 'samples/**', '.github/workflows/build-samples*.yml' ]
+  pull_request:
+    branches: [ main ]
+    paths: [ 'samples/**', '.github/workflows/build-samples*.yml' ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  datasync-server:
+    uses: ./.github/workflows/build-samples-datasync-server.yml
+
+  datasync-server-cosmosdb:
+    uses: ./.github/workflows/build-samples-datasync-server-cosmosdb.yml
+
+  todoapp-mvc:
+    uses: ./.github/workflows/build-samples-todoapp-mvc.yml
+
+  todoapp-blazor-wasm:
+    uses: ./.github/workflows/build-samples-todoapp-blazor-wasm.yml
+
+  todoapp-tutorial:
+    uses: ./.github/workflows/build-samples-todoapp-tutorial.yml
+
+  todoapp-avalonia:
+    uses: ./.github/workflows/build-samples-todoapp-avalonia.yml
+
+  # Single aggregation point so branch protection only needs to require one check,
+  # regardless of how many sample workflows are added over time (see Phase 2/3
+  # follow-ups: https://github.com/CommunityToolkit/Datasync/issues/510 and #511).
+  all-samples-built:
+    name: All samples built
+    if: always()
+    needs:
+      - datasync-server
+      - datasync-server-cosmosdb
+      - todoapp-mvc
+      - todoapp-blazor-wasm
+      - todoapp-tutorial
+      - todoapp-avalonia
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check sample build results
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ] || [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "One or more sample builds failed."
+            exit 1
+          fi
+          echo "All samples built successfully."


### PR DESCRIPTION
## Summary

Closes part of #509 (Phase 1 of the samples CI rollout).

`/samples` previously had zero CI coverage. This adds a `build-samples.yml` workflow that builds the plain `net10.0` samples with no extra workloads on `ubuntu-latest`, triggered on any PR/push to `main` touching `samples/**`.

## What's included (Phase 1 — no extra workloads, ubuntu-latest)

- `datasync-server` (`Sample.Datasync.Server.sln`)
- `datasync-server-cosmosdb-singlecontainer` (`Datasync.Server.CosmosDb.SingleContainer.sln`)
- `todoapp-mvc` (`part5.sln`)
- `todoapp-blazor-wasm` (`TodoApp.BlazorWasm.sln`)
- `todoapp-tutorial` — `ServerApp.csproj` only
- Avalonia TodoApp — shared (`TodoApp.Avalonia.csproj`) + Desktop (`TodoApp.Avalonia.Desktop.csproj`) projects directly, not the full `.sln`

## Design

- One reusable workflow file per sample (`build-samples-<name>.yml`, `on: workflow_call`), each doing `checkout` → `setup-dotnet` (10.0.x) → `dotnet restore` → `dotnet build --configuration Release`.
- A single orchestrator, `build-samples.yml`, owns the `pull_request`/`push`/`workflow_dispatch` triggers and path filter (`samples/**`, `.github/workflows/build-samples*.yml`), and calls each per-sample workflow as a job.
- An `all-samples-built` gate job aggregates the results so branch protection only needs one required check as more samples are added over time.

## Findings during implementation

While verifying the issue's inventory table against the actual sample projects, I found two things that don't fit a `ubuntu-latest`/no-workload Phase 1 build and filed them as separate follow-ups so they can be picked up independently:

- **#510** (Phase 2 — Windows-only heads): `TodoApp.WPF`, `TodoApp.WinUI3`, the MAUI Windows TFM, **and** `todoapp-tutorial/ClientApp` — which turned out to be a WPF app (`net10.0-windows`), not plain `net10.0` as originally listed in #509's table. It isn't built by this PR's workflow.
- **#511** (Phase 3 — mobile heads): Android/iOS for Avalonia and MAUI, plus Uno.

## Verification

- `actionlint` passes on all 7 new workflow files.
- Locally ran `dotnet restore` + `dotnet build --configuration Release` for each of the 6 build targets covered by this PR — all succeed with 0 errors (Blazor WASM Client builds fine without the `wasm-tools` workload, contrary to the issue's speculation that it might be needed).
- Ran a full `dotnet restore && dotnet build --configuration Release` at the repo root to confirm no regressions to the main library/test build (0 errors). Did not run the full `dotnet test` suite — this PR touches only `.github/workflows/`, and the local environment lacks Docker for the TestContainers-based integration tests (a pre-existing, unrelated environment limitation noted in the README).
