### PR TITLE
ci: add build-samples workflow for Phase 3 mobile heads (#511)

### DIFF
--- a/.github/workflows/build-samples-todoapp-avalonia.yml
+++ b/.github/workflows/build-samples-todoapp-avalonia.yml
@@ -8,18 +8,21 @@ env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
   DOTNET_CONFIGURATION: 'Release'
-  # NOTE: This sample's solution (TodoApp.Avalonia.sln) also contains Android and iOS
-  # heads (net10.0-android / net10.0-ios), which require mobile workloads and are tracked
-  # separately in https://github.com/CommunityToolkit/Datasync/issues/511 (Phase 3). Only
-  # the shared and Desktop (net10.0) projects are built directly here, not the full .sln.
+  # NOTE: This sample's solution (TodoApp.Avalonia.sln) also contains Android and iOS heads
+  # (net10.0-android / net10.0-ios). Only the shared and Desktop (net10.0) projects are built
+  # directly here, not the full .sln - the Android and iOS heads are built by their own jobs
+  # below, each restoring/building its own project directly so only the workload needed for
+  # that head is installed on that runner.
   SharedProjectFile: 'samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia/TodoApp.Avalonia.csproj'
   DesktopProjectFile: 'samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia.Desktop/TodoApp.Avalonia.Desktop.csproj'
+  AndroidProjectFile: 'samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia.Android/TodoApp.Avalonia.Android.csproj'
+  iOSProjectFile: 'samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia.iOS/TodoApp.Avalonia.iOS.csproj'
 
 permissions:
   contents: read
 
 jobs:
-  build:
+  desktop:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -45,5 +48,52 @@ jobs:
       - name: Build desktop project
         run: >
           dotnet build ${{ env.DesktopProjectFile }}
+          --configuration ${{ env.DOTNET_CONFIGURATION }}
+          --no-restore
+
+  android:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Install Android workload
+        run: dotnet workload install android
+
+      - name: Restore Android project
+        run: dotnet restore ${{ env.AndroidProjectFile }}
+
+      - name: Build Android project
+        run: >
+          dotnet build ${{ env.AndroidProjectFile }}
+          --configuration ${{ env.DOTNET_CONFIGURATION }}
+          --no-restore
+
+  ios:
+    # iOS builds require Xcode, which is only available on macOS runners.
+    runs-on: macos-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Install iOS workload
+        run: dotnet workload install ios
+
+      - name: Restore iOS project
+        run: dotnet restore ${{ env.iOSProjectFile }}
+
+      - name: Build iOS project
+        run: >
+          dotnet build ${{ env.iOSProjectFile }}
           --configuration ${{ env.DOTNET_CONFIGURATION }}
           --no-restore

--- a/.github/workflows/build-samples-todoapp-maui.yml
+++ b/.github/workflows/build-samples-todoapp-maui.yml
@@ -1,0 +1,72 @@
+name: Build Sample - TodoApp MAUI (Android / iOS)
+
+on:
+  workflow_call:
+
+env:
+  DOTNET_VERSION: '10.0.x'
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+  DOTNET_CONFIGURATION: 'Release'
+  # TodoApp.MAUI.csproj targets net10.0-android;net10.0-ios, with net10.0-windows10.0.19041.0
+  # conditionally appended only when building on Windows (that head is built separately in
+  # build-samples-todoapp-windows.yml). Restore/build here is explicitly scoped to one mobile
+  # TargetFramework per job so each runner only needs the workload for its own head.
+  MauiProjectFile: 'samples/todoapp/TodoApp.MAUI/TodoApp.MAUI.csproj'
+  AndroidTargetFramework: 'net10.0-android'
+  iOSTargetFramework: 'net10.0-ios'
+
+permissions:
+  contents: read
+
+jobs:
+  android:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Install MAUI Android workload
+        run: dotnet workload install maui-android
+
+      - name: Restore MAUI project (Android TFM only)
+        # NOTE: 'dotnet restore' has no -f|--framework option (-f means --force there, unlike
+        # 'dotnet build'). Use the MSBuild property directly to scope restore to one TFM.
+        run: dotnet restore ${{ env.MauiProjectFile }} -p:TargetFramework=${{ env.AndroidTargetFramework }}
+
+      - name: Build MAUI project (Android TFM only)
+        run: >
+          dotnet build ${{ env.MauiProjectFile }}
+          -f ${{ env.AndroidTargetFramework }}
+          --configuration ${{ env.DOTNET_CONFIGURATION }}
+          --no-restore
+
+  ios:
+    # iOS builds require Xcode, which is only available on macOS runners.
+    runs-on: macos-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Install MAUI iOS workload
+        run: dotnet workload install maui-ios
+
+      - name: Restore MAUI project (iOS TFM only)
+        run: dotnet restore ${{ env.MauiProjectFile }} -p:TargetFramework=${{ env.iOSTargetFramework }}
+
+      - name: Build MAUI project (iOS TFM only)
+        run: >
+          dotnet build ${{ env.MauiProjectFile }}
+          -f ${{ env.iOSTargetFramework }}
+          --configuration ${{ env.DOTNET_CONFIGURATION }}
+          --no-restore

--- a/.github/workflows/build-samples-todoapp-uno.yml
+++ b/.github/workflows/build-samples-todoapp-uno.yml
@@ -1,0 +1,160 @@
+name: Build Sample - TodoApp Uno
+
+on:
+  workflow_call:
+
+env:
+  DOTNET_VERSION: '10.0.x'
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_NOLOGO: true
+  DOTNET_CONFIGURATION: 'Release'
+  # TodoApp.Uno.csproj is a single Uno.Sdk project with a multi-head TargetFrameworks list
+  # (net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-windows10.0.26100;
+  # net10.0-browserwasm;net10.0-desktop). No single runner can build every head (mobile heads
+  # need Android/iOS workloads, the Windows head needs windows-latest, etc.), so each job below
+  # restores/builds one head at a time, scoped via the MSBuild TargetFramework property.
+  UnoProjectFile: 'samples/todoapp/TodoApp.Uno/TodoApp.Uno/TodoApp.Uno.csproj'
+  AndroidTargetFramework: 'net10.0-android'
+  iOSTargetFramework: 'net10.0-ios'
+  MacCatalystTargetFramework: 'net10.0-maccatalyst'
+  WindowsTargetFramework: 'net10.0-windows10.0.26100'
+  BrowserWasmTargetFramework: 'net10.0-browserwasm'
+  DesktopTargetFramework: 'net10.0-desktop'
+
+permissions:
+  contents: read
+
+jobs:
+  android:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Install Android workload
+        run: dotnet workload install android
+
+      - name: Restore Uno project (Android TFM only)
+        # NOTE: 'dotnet restore' has no -f|--framework option (-f means --force there, unlike
+        # 'dotnet build'). Use the MSBuild property directly to scope restore to one TFM.
+        run: dotnet restore ${{ env.UnoProjectFile }} -p:TargetFramework=${{ env.AndroidTargetFramework }}
+
+      - name: Build Uno project (Android TFM only)
+        run: >
+          dotnet build ${{ env.UnoProjectFile }}
+          -f ${{ env.AndroidTargetFramework }}
+          --configuration ${{ env.DOTNET_CONFIGURATION }}
+          --no-restore
+
+  ios-maccatalyst:
+    # iOS and Mac Catalyst builds both require Xcode, which is only available on macOS runners.
+    runs-on: macos-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Install iOS and Mac Catalyst workloads
+        run: dotnet workload install ios maccatalyst
+
+      - name: Restore Uno project (iOS TFM only)
+        run: dotnet restore ${{ env.UnoProjectFile }} -p:TargetFramework=${{ env.iOSTargetFramework }}
+
+      - name: Build Uno project (iOS TFM only)
+        run: >
+          dotnet build ${{ env.UnoProjectFile }}
+          -f ${{ env.iOSTargetFramework }}
+          --configuration ${{ env.DOTNET_CONFIGURATION }}
+          --no-restore
+
+      - name: Restore Uno project (Mac Catalyst TFM only)
+        run: dotnet restore ${{ env.UnoProjectFile }} -p:TargetFramework=${{ env.MacCatalystTargetFramework }}
+
+      - name: Build Uno project (Mac Catalyst TFM only)
+        run: >
+          dotnet build ${{ env.UnoProjectFile }}
+          -f ${{ env.MacCatalystTargetFramework }}
+          --configuration ${{ env.DOTNET_CONFIGURATION }}
+          --no-restore
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore Uno project (Windows TFM only)
+        run: dotnet restore ${{ env.UnoProjectFile }} -p:TargetFramework=${{ env.WindowsTargetFramework }}
+
+      - name: Build Uno project (Windows TFM only)
+        run: >
+          dotnet build ${{ env.UnoProjectFile }}
+          -f ${{ env.WindowsTargetFramework }}
+          --configuration ${{ env.DOTNET_CONFIGURATION }}
+          --no-restore
+
+  browserwasm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Install WebAssembly build tools workload
+        run: dotnet workload install wasm-tools
+
+      - name: Restore Uno project (Browser WebAssembly TFM only)
+        run: dotnet restore ${{ env.UnoProjectFile }} -p:TargetFramework=${{ env.BrowserWasmTargetFramework }}
+
+      - name: Build Uno project (Browser WebAssembly TFM only)
+        run: >
+          dotnet build ${{ env.UnoProjectFile }}
+          -f ${{ env.BrowserWasmTargetFramework }}
+          --configuration ${{ env.DOTNET_CONFIGURATION }}
+          --no-restore
+
+  desktop:
+    # NOTE: https://github.com/CommunityToolkit/Datasync/issues/506 is investigating a NU1903
+    # audit warning (Tmds.DBus) for this head; that alone does not fail restore/build since this
+    # repo does not configure NuGet audit to fail on warnings. That investigation separately
+    # reported hitting a NU1605 package-downgrade error (Uno.WinUI version floor conflict via
+    # CommunityToolkit.WinUI.Behaviors) while digging into the warning - if that reproduces here
+    # and fails this job, do not silently mark it continue-on-error; comment on #506 with the
+    # concrete failure first, since that conflict is not confirmed to be desktop-specific.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore Uno project (Desktop TFM only)
+        run: dotnet restore ${{ env.UnoProjectFile }} -p:TargetFramework=${{ env.DesktopTargetFramework }}
+
+      - name: Build Uno project (Desktop TFM only)
+        run: >
+          dotnet build ${{ env.UnoProjectFile }}
+          -f ${{ env.DesktopTargetFramework }}
+          --configuration ${{ env.DOTNET_CONFIGURATION }}
+          --no-restore

--- a/.github/workflows/build-samples-todoapp-uno.yml
+++ b/.github/workflows/build-samples-todoapp-uno.yml
@@ -1,5 +1,12 @@
 name: Build Sample - TodoApp Uno
 
+# NOTE: This workflow is NOT currently wired into build-samples.yml. TodoApp.Uno.csproj fails
+# to restore on every head with NU1605 (Uno.WinUI version downgrade caused by
+# CommunityToolkit.WinUI.Behaviors' floor vs. the Uno.Sdk pin in global.json) - see the jobs
+# below and https://github.com/CommunityToolkit/Datasync/issues/506, which is tracking the fix.
+# Re-add the `todoapp-uno` job to build-samples.yml (and to all-samples-built's `needs`) once
+# #506 is resolved and TodoApp.Uno.csproj restores cleanly.
+
 on:
   workflow_call:
 
@@ -132,13 +139,11 @@ jobs:
           --no-restore
 
   desktop:
-    # NOTE: https://github.com/CommunityToolkit/Datasync/issues/506 is investigating a NU1903
-    # audit warning (Tmds.DBus) for this head; that alone does not fail restore/build since this
-    # repo does not configure NuGet audit to fail on warnings. That investigation separately
-    # reported hitting a NU1605 package-downgrade error (Uno.WinUI version floor conflict via
-    # CommunityToolkit.WinUI.Behaviors) while digging into the warning - if that reproduces here
-    # and fails this job, do not silently mark it continue-on-error; comment on #506 with the
-    # concrete failure first, since that conflict is not confirmed to be desktop-specific.
+    # NOTE: this head (along with every other head in this file) currently fails to restore
+    # with NU1605 - see the file-level NOTE above and #506. #506 originally reported the NU1903
+    # Tmds.DBus audit warning for this head specifically; that warning alone is harmless (this
+    # repo does not configure NuGet audit to fail on warnings), but the NU1605 uncovered while
+    # investigating it turned out to be project-wide, not desktop-specific.
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/build-samples-todoapp-windows.yml
+++ b/.github/workflows/build-samples-todoapp-windows.yml
@@ -14,8 +14,8 @@ env:
   WpfProjectFile: 'samples/todoapp/TodoApp.WPF/TodoApp.WPF.csproj'
   # TodoApp.MAUI.csproj targets net10.0-android;net10.0-ios, with net10.0-windows10.0.19041.0
   # conditionally appended only when building on Windows. Android/iOS heads require separate
-  # workloads and are tracked in https://github.com/CommunityToolkit/Datasync/issues/511 (Phase 3),
-  # so restore/build here is explicitly scoped to the Windows TargetFramework only.
+  # workloads and are built by build-samples-todoapp-maui.yml instead, so restore/build here is
+  # explicitly scoped to the Windows TargetFramework only.
   MauiProjectFile: 'samples/todoapp/TodoApp.MAUI/TodoApp.MAUI.csproj'
   MauiWindowsTargetFramework: 'net10.0-windows10.0.19041.0'
 

--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -34,9 +34,14 @@ jobs:
   todoapp-windows:
     uses: ./.github/workflows/build-samples-todoapp-windows.yml
 
+  todoapp-maui:
+    uses: ./.github/workflows/build-samples-todoapp-maui.yml
+
+  todoapp-uno:
+    uses: ./.github/workflows/build-samples-todoapp-uno.yml
+
   # Single aggregation point so branch protection only needs to require one check,
-  # regardless of how many sample workflows are added over time (see Phase 3
-  # follow-up: https://github.com/CommunityToolkit/Datasync/issues/511).
+  # regardless of how many sample workflows are added over time.
   all-samples-built:
     name: All samples built
     if: always()
@@ -48,6 +53,8 @@ jobs:
       - todoapp-tutorial
       - todoapp-avalonia
       - todoapp-windows
+      - todoapp-maui
+      - todoapp-uno
     runs-on: ubuntu-latest
     steps:
       - name: Check sample build results

--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -37,8 +37,17 @@ jobs:
   todoapp-maui:
     uses: ./.github/workflows/build-samples-todoapp-maui.yml
 
-  todoapp-uno:
-    uses: ./.github/workflows/build-samples-todoapp-uno.yml
+  # NOTE: todoapp-uno (build-samples-todoapp-uno.yml) is intentionally NOT wired in here.
+  # TodoApp.Uno.csproj fails to restore on every head with:
+  #   NU1605: Detected package downgrade: Uno.WinUI from 5.5.87 to 5.4.22
+  #   TodoApp.Uno -> CommunityToolkit.WinUI.Behaviors 8.2.250402 -> Uno.WinUI (>= 5.5.87)
+  #   TodoApp.Uno -> Uno.WinUI (>= 5.4.22)
+  # This is unconditional (CommunityToolkit.WinUI.Behaviors has no TFM condition on its
+  # PackageReference), so it blocks every TFM, not just the desktop head as originally
+  # suspected. See https://github.com/CommunityToolkit/Datasync/issues/506, which is tracking
+  # the underlying Uno.WinUI/CommunityToolkit.WinUI.Behaviors version conflict. Re-enable this
+  # job (add it back to the jobs list and to all-samples-built's needs below) once #506 is
+  # resolved and TodoApp.Uno.csproj restores cleanly.
 
   # Single aggregation point so branch protection only needs to require one check,
   # regardless of how many sample workflows are added over time.
@@ -54,7 +63,6 @@ jobs:
       - todoapp-avalonia
       - todoapp-windows
       - todoapp-maui
-      - todoapp-uno
     runs-on: ubuntu-latest
     steps:
       - name: Check sample build results

--- a/samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia.iOS/Info.plist
+++ b/samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia.iOS/Info.plist
@@ -13,7 +13,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>13.0</string>
+	<string>15.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>


### PR DESCRIPTION
## Summary

Closes #511 (Phase 3 of the samples CI rollout, follow-up to #509 / #510).

Adds CI coverage for the mobile build heads (Android/iOS/Uno) deferred from Phase 1 (#509, merged in #512) and Phase 2 (#510, merged in #514).

## Scope

| Sample | Project(s) | TFM(s) | Runner / workload |
|---|---|---|---|
| Avalonia TodoApp | `TodoApp.Avalonia.Android.csproj` | `net10.0-android` | `ubuntu-latest`, `android` workload |
| Avalonia TodoApp | `TodoApp.Avalonia.iOS.csproj` | `net10.0-ios` | `macos-latest`, `ios` workload |
| MAUI TodoApp | `TodoApp.MAUI.csproj` | `net10.0-android` | `ubuntu-latest`, `maui-android` workload |
| MAUI TodoApp | `TodoApp.MAUI.csproj` | `net10.0-ios` | `macos-latest`, `maui-ios` workload |
| Uno TodoApp | `TodoApp.Uno.csproj` | `net10.0-android` | `ubuntu-latest`, `android` workload |
| Uno TodoApp | `TodoApp.Uno.csproj` | `net10.0-ios` / `net10.0-maccatalyst` | `macos-latest`, `ios` + `maccatalyst` workloads |
| Uno TodoApp | `TodoApp.Uno.csproj` | `net10.0-windows10.0.26100` | `windows-latest` |
| Uno TodoApp | `TodoApp.Uno.csproj` | `net10.0-browserwasm` | `ubuntu-latest`, `wasm-tools` workload |
| Uno TodoApp | `TodoApp.Uno.csproj` | `net10.0-desktop` | `ubuntu-latest` |

Build-only (`dotnet restore` + `dotnet build`), consistent with Phases 1 and 2.

## Changes

- **Modified** `build-samples-todoapp-avalonia.yml` — renamed the existing job `build` → `desktop`; added `android` (`ubuntu-latest`) and `ios` (`macos-latest`) jobs for the Android/iOS heads. Removed the now-resolved comment deferring these to #511.
- **New** `build-samples-todoapp-maui.yml` — `android` and `ios` jobs for `TodoApp.MAUI.csproj`. Since the project has multiple TFMs (`net10.0-android;net10.0-ios`, plus a Windows TFM conditionally appended on Windows), each job scopes restore/build to a single TargetFramework via `-p:TargetFramework` (restore) / `-f` (build), mirroring the pattern already used for the MAUI-Windows head in #514. The Windows head remains in `build-samples-todoapp-windows.yml`, unchanged.
- **New** `build-samples-todoapp-uno.yml` — `TodoApp.Uno.csproj` is a single Uno.Sdk project with a multi-head `TargetFrameworks` list (`net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-windows10.0.26100;net10.0-browserwasm;net10.0-desktop`). No single runner can build every head, so each job restores/builds one head at a time via the same TFM-scoping pattern: `android` (ubuntu), `ios-maccatalyst` (macos, one job installs both workloads and builds both heads sequentially), `windows` (windows-latest), `browserwasm` (ubuntu, `wasm-tools`), `desktop` (ubuntu).
- **Modified** `build-samples.yml` — wired `todoapp-maui` and `todoapp-uno` into the orchestrator and the `all-samples-built` gate job; cleaned up the resolved Phase 3 comment.
- **Modified** `build-samples-todoapp-windows.yml` — updated a comment to point at the new `build-samples-todoapp-maui.yml` instead of #511 (now resolved).

## A note on the Uno `desktop` head and #506

#511 suggested `continue-on-error: true` (or excluding entirely) for the Uno `desktop` head, citing a pre-existing `NU1605` mentioned in #506. I did **not** apply that here, deliberately:

- #506's actual subject is a NuGet Audit **warning** (`NU1903`, `Tmds.DBus`). This repo does not configure NuGet audit to fail builds anywhere (no `NuGetAuditMode`/`WarningsAsErrors` overrides found in any `Directory.Build.props`/`Directory.Packages.props`), so that finding alone cannot fail `dotnet restore`/`build` regardless of head.
- #506 separately reports hitting a `NU1605` (package downgrade, a genuine restore **error** if it reproduces) while investigating the warning above. However: (a) #506 is still open/unresolved, so this isn't confirmed to still reproduce; and (b) the implicated package (`CommunityToolkit.WinUI.Behaviors`) is referenced **unconditionally** in `TodoApp.Uno.csproj`, not scoped to the desktop TFM, so if this conflict is real it isn't necessarily desktop-specific.

All five Uno jobs are left as normal, blocking jobs pending real CI signal from this PR. If any job fails with the NU1605 described in #506, I'll add `continue-on-error` to just that job and report back to #506 with the concrete reproduction, rather than speculatively excluding a head that may build fine.

## Verification

- `actionlint` passes on all 5 changed/new workflow files.
- `dotnet restore Datasync.Toolkit.sln && dotnet build Datasync.Toolkit.sln --configuration Release --no-restore` succeeds with 0 warnings/errors (confirms no regression to the core library build).
- **Not verified locally**: the actual workload installs and builds for the Android, iOS, and Uno heads. This dev environment is macOS with no Android SDK, no full Xcode (Command Line Tools only), and no Windows, so these steps can only be exercised once this PR's CI actually runs — same limitation documented in #514 for the Phase 2 Windows heads.

## Related

- #509 — Phase 1 (ubuntu-only, no-workload samples), merged in #512.
- #510 — Phase 2 (Windows-only heads), merged in #514.
- #506 — Uno `Tmds.DBus` NU1903 investigation; still open, discussed above.
- #518 — separate, unrelated `shellcheck`/`actionlint` cleanup found incidentally while verifying this PR's workflow files; filed independently to keep this PR scoped to samples CI.
