### PR TITLE
fix: resolve NU1605 blocking TodoApp.Uno restore by bumping Uno.Sdk to 5.6.54

### DIFF
--- a/.github/workflows/build-samples-todoapp-uno.yml
+++ b/.github/workflows/build-samples-todoapp-uno.yml
@@ -1,11 +1,13 @@
 name: Build Sample - TodoApp Uno
 
-# NOTE: This workflow is NOT currently wired into build-samples.yml. TodoApp.Uno.csproj fails
-# to restore on every head with NU1605 (Uno.WinUI version downgrade caused by
-# CommunityToolkit.WinUI.Behaviors' floor vs. the Uno.Sdk pin in global.json) - see the jobs
-# below and https://github.com/CommunityToolkit/Datasync/issues/506, which is tracking the fix.
-# Re-add the `todoapp-uno` job to build-samples.yml (and to all-samples-built's `needs`) once
-# #506 is resolved and TodoApp.Uno.csproj restores cleanly.
+# NOTE: This workflow is NOT currently wired into build-samples.yml. #506 fixed the NU1605
+# restore blocker that used to affect every head (see samples/todoapp/TodoApp.Uno/global.json),
+# so restore now succeeds everywhere. However, build now fails on every Skia-based head (android,
+# ios, maccatalyst, browserwasm, desktop) with UXAML0001/CS1061 (EventTriggerBehavior could not
+# be found) - see the `desktop` job below for details and
+# https://github.com/CommunityToolkit/Datasync/issues/506 for background. Re-add the
+# `todoapp-uno` job to build-samples.yml (and to all-samples-built's `needs`) once that build
+# failure is resolved and every head restores AND builds cleanly.
 
 on:
   workflow_call:
@@ -139,11 +141,27 @@ jobs:
           --no-restore
 
   desktop:
-    # NOTE: this head (along with every other head in this file) currently fails to restore
-    # with NU1605 - see the file-level NOTE above and #506. #506 originally reported the NU1903
-    # Tmds.DBus audit warning for this head specifically; that warning alone is harmless (this
-    # repo does not configure NuGet audit to fail on warnings), but the NU1605 uncovered while
-    # investigating it turned out to be project-wide, not desktop-specific.
+    # NOTE: this head (along with every other Skia-based head in this file - android,
+    # ios-maccatalyst, browserwasm) currently fails to BUILD (not restore) with:
+    #   error UXAML0001: The type {using:Microsoft.Xaml.Interactions.Core}EventTriggerBehavior
+    #   could not be found
+    # CommunityToolkit.WinUI.Behaviors 8.2.250402 resolves
+    # Uno.Microsoft.Xaml.Behaviors.Interactivity.WinUI 3.0.0-dev.17.g7c09b9114d on Skia heads
+    # (confirmed via project.assets.json for desktop and browserwasm), which appears to lack the
+    # Microsoft.Xaml.Interactions.Core types used in Views/TodoListPage.xaml. The `windows` job
+    # below is unaffected - it resolves the real Microsoft.Xaml.Behaviors.WinUI.Managed 3.0.0
+    # package instead. This is a separate, pre-existing bug from the NU1903 Tmds.DBus finding
+    # below and from the NU1605 restore blocker #506 originally hit (now fixed - see
+    # samples/todoapp/TodoApp.Uno/global.json) - it was never surfaced before because restore
+    # always failed first. Tracked as a #506 follow-up issue.
+    #
+    # Restore also emits a NU1903 warning for 'Tmds.DBus' 0.16.0 (GHSA-xrw6-gwf8-vvr9 /
+    # CVE-2026-39959), floated transitively via Uno.WinUI.Runtime.Skia.X11. This is harmless as a
+    # CI matter today (this repo does not configure NuGet audit to fail on warnings) but is not
+    # yet resolved - Uno only switches Uno.WinUI.Runtime.Skia.X11 to the patched
+    # Tmds.DBus.Protocol starting at Uno.WinUI 6.0.465, which requires a major-version bump of
+    # Uno.Sdk. See https://github.com/CommunityToolkit/Datasync/issues/506 for background and the
+    # tracked major-version-bump follow-up issue.
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -37,17 +37,20 @@ jobs:
   todoapp-maui:
     uses: ./.github/workflows/build-samples-todoapp-maui.yml
 
-  # NOTE: todoapp-uno (build-samples-todoapp-uno.yml) is intentionally NOT wired in here.
-  # TodoApp.Uno.csproj fails to restore on every head with:
-  #   NU1605: Detected package downgrade: Uno.WinUI from 5.5.87 to 5.4.22
-  #   TodoApp.Uno -> CommunityToolkit.WinUI.Behaviors 8.2.250402 -> Uno.WinUI (>= 5.5.87)
-  #   TodoApp.Uno -> Uno.WinUI (>= 5.4.22)
-  # This is unconditional (CommunityToolkit.WinUI.Behaviors has no TFM condition on its
-  # PackageReference), so it blocks every TFM, not just the desktop head as originally
-  # suspected. See https://github.com/CommunityToolkit/Datasync/issues/506, which is tracking
-  # the underlying Uno.WinUI/CommunityToolkit.WinUI.Behaviors version conflict. Re-enable this
-  # job (add it back to the jobs list and to all-samples-built's needs below) once #506 is
-  # resolved and TodoApp.Uno.csproj restores cleanly.
+  # NOTE: todoapp-uno (build-samples-todoapp-uno.yml) is intentionally NOT wired in here yet.
+  # #506 fixed the NU1605 restore blocker that used to affect every head (bumped Uno.Sdk in
+  # samples/todoapp/TodoApp.Uno/global.json from 5.4.5 to 5.6.54), so TodoApp.Uno.csproj now
+  # restores cleanly. However, restoring cleanly surfaced a separate, pre-existing bug: on every
+  # Skia-based head (android, ios, maccatalyst, browserwasm, desktop - confirmed for desktop and
+  # browserwasm; android/ios/maccatalyst require workloads not available where this was
+  # verified), CommunityToolkit.WinUI.Behaviors 8.2.250402 resolves
+  # Uno.Microsoft.Xaml.Behaviors.Interactivity.WinUI 3.0.0-dev.17.g7c09b9114d instead of the real
+  # Microsoft.Xaml.Behaviors.WinUI.Managed package (which the windows head still gets), and that
+  # substitute is missing the Microsoft.Xaml.Interactions.Core types used in
+  # Views/TodoListPage.xaml, so build fails with UXAML0001/CS1061 (EventTriggerBehavior could not
+  # be found). This was never surfaced before because restore always failed first. See the
+  # tracking issue for this build failure (filed as a #506 follow-up) - re-add this job once
+  # that's resolved and every head restores AND builds cleanly.
 
   # Single aggregation point so branch protection only needs to require one check,
   # regardless of how many sample workflows are added over time.

--- a/samples/todoapp/TodoApp.Uno/global.json
+++ b/samples/todoapp/TodoApp.Uno/global.json
@@ -1,7 +1,14 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
+  // Bumped from 5.4.5 (-> Uno.WinUI 5.4.22) to 5.6.54 (-> Uno.WinUI 5.6.99) to resolve NU1605:
+  // CommunityToolkit.WinUI.Behaviors 8.2.250402 floors Uno.WinUI at >= 5.5.87, which is higher
+  // than what Uno.Sdk 5.4.5 resolves, causing a package-downgrade restore error on every head.
+  // This does NOT resolve the separate NU1903 (Tmds.DBus 0.16.0) advisory on the desktop head -
+  // Uno.WinUI.Runtime.Skia.X11 keeps floating vulnerable Tmds.DBus 0.16.0 through the entire
+  // 5.x line and only switches to the patched Tmds.DBus.Protocol starting at Uno.WinUI 6.0.465.
+  // See https://github.com/CommunityToolkit/Datasync/issues/506.
   "msbuild-sdks": {
-    "Uno.Sdk": "5.4.5"
+    "Uno.Sdk": "5.6.54"
   },
   "sdk":{
     "allowPrerelease": false


### PR DESCRIPTION
## Summary

Resolves the NU1605 restore blocker for #506. `CommunityToolkit.WinUI.Behaviors 8.2.250402` (pinned in `samples/todoapp/TodoApp.Uno/Directory.Packages.props`) floors `Uno.WinUI` at `>= 5.5.87`, but `Uno.Sdk 5.4.5` (the previous `global.json` pin) resolves `Uno.WinUI` to `5.4.22`, causing:

```
error NU1605: Detected package downgrade: Uno.WinUI from 5.5.87 to 5.4.22
  TodoApp.Uno -> CommunityToolkit.WinUI.Behaviors 8.2.250402 -> Uno.WinUI (>= 5.5.87)
  TodoApp.Uno -> Uno.WinUI (>= 5.4.22)
```

on **every** head (android, ios, maccatalyst, windows, browserwasm, desktop) - not just the desktop head #506 originally reported (confirmed in [this comment](https://github.com/CommunityToolkit/Datasync/issues/506#issuecomment-4904583488)).

## Changes

- Bumped `Uno.Sdk` in `samples/todoapp/TodoApp.Uno/global.json` from `5.4.5` to `5.6.54` (the latest stable 5.x release), which resolves `Uno.WinUI` to `5.6.99`, clearing the `>= 5.5.87` floor. Confirmed via nupkg/nuspec inspection that this is the smallest Uno.Sdk change that stays within the current major version (avoids the larger 6.x migration effort called out in #506).
- Updated the NOTE comments in `build-samples.yml` and `build-samples-todoapp-uno.yml` to reflect the new state.

## What this does NOT resolve

- **The original NU1903 finding** (`Tmds.DBus` 0.16.0, [GHSA-xrw6-gwf8-vvr9](https://github.com/advisories/GHSA-xrw6-gwf8-vvr9)) that #506 was filed for. `Uno.WinUI.Runtime.Skia.X11` floats vulnerable `Tmds.DBus 0.16.0` unchanged through the entire 5.x line (confirmed at 5.4.22, 5.5.87, 5.5.95, 5.6.99) and only switches to the patched `Tmds.DBus.Protocol` starting at Uno.WinUI 6.0.465 - a major-version bump. Filed as a follow-up: #524.
- **A separate, pre-existing build failure** on every Skia-based head (desktop, browserwasm, and almost certainly android/ios/maccatalyst), surfaced now that restore succeeds: `CommunityToolkit.WinUI.Behaviors` resolves a dev-prerelease `Uno.Microsoft.Xaml.Behaviors.Interactivity.WinUI` package on those heads (instead of the real `Microsoft.Xaml.Behaviors.WinUI.Managed`, which the `windows` head still gets), which appears to be missing the `Microsoft.Xaml.Interactions.Core` types used in `Views/TodoListPage.xaml`, causing `UXAML0001`/`CS1061` build errors. This was never surfaced before because restore always failed first. Filed as a follow-up: #525.
- **Two more NU1903 findings** (`System.Security.Cryptography.Xml` 8.0.2) surfaced on the `browserwasm` head restore, also previously masked by NU1605. Filed as a follow-up: #526.

Given the above, the `todoapp-uno` CI job (`build-samples-todoapp-uno.yml`) is **intentionally left unwired** in `build-samples.yml` - re-enabling it today would turn `all-samples-built` red on every future PR due to #525's build failure. It should be re-wired once #525 (at minimum) is resolved.

## Validation

- `dotnet restore samples/todoapp/TodoApp.Uno/TodoApp.Uno/TodoApp.Uno.csproj -p:TargetFramework=net10.0-desktop` - succeeds, NU1605 gone, NU1903 (Tmds.DBus) warning still present as expected/documented.
- `dotnet restore ... -p:TargetFramework=net10.0-windows10.0.26100` - succeeds cleanly, no NU1903 warnings (resolves the real `Microsoft.Xaml.Behaviors.WinUI.Managed`).
- `dotnet restore ... -p:TargetFramework=net10.0-browserwasm` - succeeds, surfaces the two `System.Security.Cryptography.Xml` NU1903 findings noted above (#526).
- `dotnet build ... -f net10.0-desktop` - fails with the pre-existing `EventTriggerBehavior` bug (#525), unrelated to this change.
- Could not restore/build `android`/`ios`/`maccatalyst` locally (missing `android`/`ios`/`maccatalyst` workloads in this environment) - same limitation noted in PR #508 for the Avalonia sample.
- `dotnet build Datasync.Toolkit.sln --configuration Release` (root solution, unaffected by this samples-only change) - succeeds, 0 warnings, 0 errors.

## Follow-ups filed

- #524 - major-version bump (Uno 5 -> 6) needed to fully resolve the `Tmds.DBus` NU1903 finding.
- #525 - `EventTriggerBehavior` build failure on Skia heads, blocking CI re-enablement.
- #526 - `System.Security.Cryptography.Xml` NU1903 finding on the browserwasm head.

Fixes #506