### PR TITLE
Replace obsolete DisplayAlert with DisplayAlertAsync

### DIFF
--- a/samples/todoapp/TodoApp.MAUI/Services/AlertService.cs
+++ b/samples/todoapp/TodoApp.MAUI/Services/AlertService.cs
@@ -11,5 +11,5 @@ public interface IAlertService
 public class AlertService : IAlertService
 {
     public Task ShowErrorAlertAsync(string title, string message, string cancel = "OK")
-        => Application.Current!.Windows[0].Page!.DisplayAlert(title, message, cancel);
+        => Application.Current!.Windows[0].Page!.DisplayAlertAsync(title, message, cancel);
 }


### PR DESCRIPTION
## Summary

Replaced the obsolete `DisplayAlert` API with `DisplayAlertAsync` in `AlertService` to use the current .NET MAUI API.

## Changes

- Replaced `DisplayAlert` with `DisplayAlertAsync`
- No functional behavior changes intended

## Testing

- Built the `Samples.TodoApp` solution
- Verified the change is limited to `AlertService.cs`