### PR TITLE
fix: suppress IL2026/IL2104 trim analysis warnings on mobile TodoApp samples

### DIFF
--- a/.github/workflows/build-samples-datasync-server-cosmosdb.yml
+++ b/.github/workflows/build-samples-datasync-server-cosmosdb.yml
@@ -7,7 +7,11 @@ env:
   DOTNET_VERSION: '10.0.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
-  DOTNET_CONFIGURATION: 'Release'
+  # Debug (not Release): this is a build-only compile sanity check, never published/shipped.
+  # Release builds pointlessly enable IL trimming/AOT machinery on some sample heads (see
+  # https://github.com/CommunityToolkit/Datasync/issues/521), so all sample CI workflows build
+  # Debug to avoid that overhead consistently, even where it isn't currently an issue.
+  DOTNET_CONFIGURATION: 'Debug'
   SolutionFile: 'samples/datasync-server-cosmosdb-singlecontainer/Datasync.Server.CosmosDb.SingleContainer.sln'
 
 permissions:

--- a/.github/workflows/build-samples-datasync-server.yml
+++ b/.github/workflows/build-samples-datasync-server.yml
@@ -7,7 +7,11 @@ env:
   DOTNET_VERSION: '10.0.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
-  DOTNET_CONFIGURATION: 'Release'
+  # Debug (not Release): this is a build-only compile sanity check, never published/shipped.
+  # Release builds pointlessly enable IL trimming/AOT machinery on some sample heads (see
+  # https://github.com/CommunityToolkit/Datasync/issues/521), so all sample CI workflows build
+  # Debug to avoid that overhead consistently, even where it isn't currently an issue.
+  DOTNET_CONFIGURATION: 'Debug'
   SolutionFile: 'samples/datasync-server/Sample.Datasync.Server.sln'
 
 permissions:

--- a/.github/workflows/build-samples-todoapp-avalonia.yml
+++ b/.github/workflows/build-samples-todoapp-avalonia.yml
@@ -126,16 +126,20 @@ jobs:
         run: dotnet restore ${{ env.iOSProjectFile }}
 
       - name: Build iOS project
-        # -p:PublishTrimmed=false: net10.0-ios Release builds run the real ILLink trimmer
-        # (not just the trim analyzer) even for a plain `dotnet build` of a simulator RID -
+        # -p:MtouchLink=None: net10.0-ios Release builds run the real ILLink trimmer (not
+        # just the trim analyzer) even for a plain `dotnet build` of a simulator RID -
         # "Optimizing assemblies for size"/"IL stripping assemblies" dominates ~90% of the
         # build time here (15+ minutes). This job never publishes or ships an app - it's a
-        # build-only sanity check - so there's no benefit to actually linking. Passed only on
-        # the command line (not set in the .csproj) so a real `dotnet publish` by a developer
-        # following the tutorial still gets the platform's normal trimming default. See
-        # https://github.com/CommunityToolkit/Datasync/issues/521.
+        # build-only sanity check - so there's no benefit to actually linking.
+        # `-p:PublishTrimmed=false` is rejected by the SDK for iOS ("iOS projects must build
+        # with PublishTrimmed=true ... Set 'MtouchLink=None' instead to disable trimming for
+        # all assemblies" - Xamarin.Shared.Sdk.targets); MtouchLink=None is the SDK-blessed
+        # way to keep PublishTrimmed=true while skipping the actual link/strip step. Passed
+        # only on the command line (not set in the .csproj) so a real `dotnet publish` by a
+        # developer following the tutorial still gets the platform's normal trimming default.
+        # See https://github.com/CommunityToolkit/Datasync/issues/521.
         run: >
           dotnet build ${{ env.iOSProjectFile }}
           --configuration ${{ env.DOTNET_CONFIGURATION }}
           --no-restore
-          -p:PublishTrimmed=false
+          -p:MtouchLink=None

--- a/.github/workflows/build-samples-todoapp-avalonia.yml
+++ b/.github/workflows/build-samples-todoapp-avalonia.yml
@@ -126,7 +126,16 @@ jobs:
         run: dotnet restore ${{ env.iOSProjectFile }}
 
       - name: Build iOS project
+        # -p:PublishTrimmed=false: net10.0-ios Release builds run the real ILLink trimmer
+        # (not just the trim analyzer) even for a plain `dotnet build` of a simulator RID -
+        # "Optimizing assemblies for size"/"IL stripping assemblies" dominates ~90% of the
+        # build time here (15+ minutes). This job never publishes or ships an app - it's a
+        # build-only sanity check - so there's no benefit to actually linking. Passed only on
+        # the command line (not set in the .csproj) so a real `dotnet publish` by a developer
+        # following the tutorial still gets the platform's normal trimming default. See
+        # https://github.com/CommunityToolkit/Datasync/issues/521.
         run: >
           dotnet build ${{ env.iOSProjectFile }}
           --configuration ${{ env.DOTNET_CONFIGURATION }}
           --no-restore
+          -p:PublishTrimmed=false

--- a/.github/workflows/build-samples-todoapp-avalonia.yml
+++ b/.github/workflows/build-samples-todoapp-avalonia.yml
@@ -7,7 +7,15 @@ env:
   DOTNET_VERSION: '10.0.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
-  DOTNET_CONFIGURATION: 'Release'
+  # Debug (not Release): this is a build-only compile sanity check, never published/shipped.
+  # Release triggers the real ILLink trimmer (not just the trim analyzer) on the iOS head even
+  # for a plain `dotnet build` of a simulator RID - "Optimizing assemblies for
+  # size"/"IL stripping assemblies" dominated ~90% of that job's build time (15+ minutes).
+  # Debug avoids that IL trimming/AOT machinery entirely (see
+  # https://blog.verslu.is/maui/exclude-assemblies-from-trimming/ and
+  # https://github.com/CommunityToolkit/Datasync/issues/521), so all sample CI workflows build
+  # Debug for consistency, even on heads where it isn't currently an issue.
+  DOTNET_CONFIGURATION: 'Debug'
   # NOTE: This sample's solution (TodoApp.Avalonia.sln) also contains Android and iOS heads
   # (net10.0-android / net10.0-ios). Only the shared and Desktop (net10.0) projects are built
   # directly here, not the full .sln - the Android and iOS heads are built by their own jobs
@@ -126,20 +134,7 @@ jobs:
         run: dotnet restore ${{ env.iOSProjectFile }}
 
       - name: Build iOS project
-        # -p:MtouchLink=None: net10.0-ios Release builds run the real ILLink trimmer (not
-        # just the trim analyzer) even for a plain `dotnet build` of a simulator RID -
-        # "Optimizing assemblies for size"/"IL stripping assemblies" dominates ~90% of the
-        # build time here (15+ minutes). This job never publishes or ships an app - it's a
-        # build-only sanity check - so there's no benefit to actually linking.
-        # `-p:PublishTrimmed=false` is rejected by the SDK for iOS ("iOS projects must build
-        # with PublishTrimmed=true ... Set 'MtouchLink=None' instead to disable trimming for
-        # all assemblies" - Xamarin.Shared.Sdk.targets); MtouchLink=None is the SDK-blessed
-        # way to keep PublishTrimmed=true while skipping the actual link/strip step. Passed
-        # only on the command line (not set in the .csproj) so a real `dotnet publish` by a
-        # developer following the tutorial still gets the platform's normal trimming default.
-        # See https://github.com/CommunityToolkit/Datasync/issues/521.
         run: >
           dotnet build ${{ env.iOSProjectFile }}
           --configuration ${{ env.DOTNET_CONFIGURATION }}
           --no-restore
-          -p:MtouchLink=None

--- a/.github/workflows/build-samples-todoapp-blazor-wasm.yml
+++ b/.github/workflows/build-samples-todoapp-blazor-wasm.yml
@@ -7,7 +7,11 @@ env:
   DOTNET_VERSION: '10.0.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
-  DOTNET_CONFIGURATION: 'Release'
+  # Debug (not Release): this is a build-only compile sanity check, never published/shipped.
+  # Release builds pointlessly enable IL trimming/AOT machinery on some sample heads (see
+  # https://github.com/CommunityToolkit/Datasync/issues/521), so all sample CI workflows build
+  # Debug to avoid that overhead consistently, even where it isn't currently an issue.
+  DOTNET_CONFIGURATION: 'Debug'
   SolutionFile: 'samples/todoapp-blazor-wasm/TodoApp.BlazorWasm.sln'
 
 permissions:

--- a/.github/workflows/build-samples-todoapp-maui.yml
+++ b/.github/workflows/build-samples-todoapp-maui.yml
@@ -98,17 +98,21 @@ jobs:
         run: dotnet restore ${{ env.MauiProjectFile }} -p:TargetFramework=${{ env.iOSTargetFramework }}
 
       - name: Build MAUI project (iOS TFM only)
-        # -p:PublishTrimmed=false: net10.0-ios Release builds run the real ILLink trimmer
-        # (not just the trim analyzer) even for a plain `dotnet build` of a simulator RID -
+        # -p:MtouchLink=None: net10.0-ios Release builds run the real ILLink trimmer (not
+        # just the trim analyzer) even for a plain `dotnet build` of a simulator RID -
         # "Optimizing assemblies for size"/"IL stripping assemblies" dominates ~90% of the
         # build time here (15+ minutes). This job never publishes or ships an app - it's a
-        # build-only sanity check - so there's no benefit to actually linking. Passed only on
-        # the command line (not set in the .csproj) so a real `dotnet publish` by a developer
-        # following the tutorial still gets the platform's normal trimming default. See
-        # https://github.com/CommunityToolkit/Datasync/issues/521.
+        # build-only sanity check - so there's no benefit to actually linking.
+        # `-p:PublishTrimmed=false` is rejected by the SDK for iOS ("iOS projects must build
+        # with PublishTrimmed=true ... Set 'MtouchLink=None' instead to disable trimming for
+        # all assemblies" - Xamarin.Shared.Sdk.targets); MtouchLink=None is the SDK-blessed
+        # way to keep PublishTrimmed=true while skipping the actual link/strip step. Passed
+        # only on the command line (not set in the .csproj) so a real `dotnet publish` by a
+        # developer following the tutorial still gets the platform's normal trimming default.
+        # See https://github.com/CommunityToolkit/Datasync/issues/521.
         run: >
           dotnet build ${{ env.MauiProjectFile }}
           -f ${{ env.iOSTargetFramework }}
           --configuration ${{ env.DOTNET_CONFIGURATION }}
           --no-restore
-          -p:PublishTrimmed=false
+          -p:MtouchLink=None

--- a/.github/workflows/build-samples-todoapp-maui.yml
+++ b/.github/workflows/build-samples-todoapp-maui.yml
@@ -7,7 +7,15 @@ env:
   DOTNET_VERSION: '10.0.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
-  DOTNET_CONFIGURATION: 'Release'
+  # Debug (not Release): this is a build-only compile sanity check, never published/shipped.
+  # Release triggers the real ILLink trimmer (not just the trim analyzer) on the iOS head even
+  # for a plain `dotnet build` of a simulator RID - "Optimizing assemblies for
+  # size"/"IL stripping assemblies" dominated ~90% of that job's build time (15+ minutes).
+  # Debug avoids that IL trimming/AOT machinery entirely (see
+  # https://blog.verslu.is/maui/exclude-assemblies-from-trimming/ and
+  # https://github.com/CommunityToolkit/Datasync/issues/521), so all sample CI workflows build
+  # Debug for consistency, even on heads where it isn't currently an issue.
+  DOTNET_CONFIGURATION: 'Debug'
   # TodoApp.MAUI.csproj targets net10.0-android;net10.0-ios, with net10.0-windows10.0.19041.0
   # conditionally appended only when building on Windows (that head is built separately in
   # build-samples-todoapp-windows.yml). Restore/build here is explicitly scoped to one mobile
@@ -98,21 +106,8 @@ jobs:
         run: dotnet restore ${{ env.MauiProjectFile }} -p:TargetFramework=${{ env.iOSTargetFramework }}
 
       - name: Build MAUI project (iOS TFM only)
-        # -p:MtouchLink=None: net10.0-ios Release builds run the real ILLink trimmer (not
-        # just the trim analyzer) even for a plain `dotnet build` of a simulator RID -
-        # "Optimizing assemblies for size"/"IL stripping assemblies" dominates ~90% of the
-        # build time here (15+ minutes). This job never publishes or ships an app - it's a
-        # build-only sanity check - so there's no benefit to actually linking.
-        # `-p:PublishTrimmed=false` is rejected by the SDK for iOS ("iOS projects must build
-        # with PublishTrimmed=true ... Set 'MtouchLink=None' instead to disable trimming for
-        # all assemblies" - Xamarin.Shared.Sdk.targets); MtouchLink=None is the SDK-blessed
-        # way to keep PublishTrimmed=true while skipping the actual link/strip step. Passed
-        # only on the command line (not set in the .csproj) so a real `dotnet publish` by a
-        # developer following the tutorial still gets the platform's normal trimming default.
-        # See https://github.com/CommunityToolkit/Datasync/issues/521.
         run: >
           dotnet build ${{ env.MauiProjectFile }}
           -f ${{ env.iOSTargetFramework }}
           --configuration ${{ env.DOTNET_CONFIGURATION }}
           --no-restore
-          -p:MtouchLink=None

--- a/.github/workflows/build-samples-todoapp-maui.yml
+++ b/.github/workflows/build-samples-todoapp-maui.yml
@@ -98,8 +98,17 @@ jobs:
         run: dotnet restore ${{ env.MauiProjectFile }} -p:TargetFramework=${{ env.iOSTargetFramework }}
 
       - name: Build MAUI project (iOS TFM only)
+        # -p:PublishTrimmed=false: net10.0-ios Release builds run the real ILLink trimmer
+        # (not just the trim analyzer) even for a plain `dotnet build` of a simulator RID -
+        # "Optimizing assemblies for size"/"IL stripping assemblies" dominates ~90% of the
+        # build time here (15+ minutes). This job never publishes or ships an app - it's a
+        # build-only sanity check - so there's no benefit to actually linking. Passed only on
+        # the command line (not set in the .csproj) so a real `dotnet publish` by a developer
+        # following the tutorial still gets the platform's normal trimming default. See
+        # https://github.com/CommunityToolkit/Datasync/issues/521.
         run: >
           dotnet build ${{ env.MauiProjectFile }}
           -f ${{ env.iOSTargetFramework }}
           --configuration ${{ env.DOTNET_CONFIGURATION }}
           --no-restore
+          -p:PublishTrimmed=false

--- a/.github/workflows/build-samples-todoapp-mvc.yml
+++ b/.github/workflows/build-samples-todoapp-mvc.yml
@@ -7,7 +7,11 @@ env:
   DOTNET_VERSION: '10.0.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
-  DOTNET_CONFIGURATION: 'Release'
+  # Debug (not Release): this is a build-only compile sanity check, never published/shipped.
+  # Release builds pointlessly enable IL trimming/AOT machinery on some sample heads (see
+  # https://github.com/CommunityToolkit/Datasync/issues/521), so all sample CI workflows build
+  # Debug to avoid that overhead consistently, even where it isn't currently an issue.
+  DOTNET_CONFIGURATION: 'Debug'
   SolutionFile: 'samples/todoapp-mvc/part5.sln'
 
 permissions:

--- a/.github/workflows/build-samples-todoapp-tutorial.yml
+++ b/.github/workflows/build-samples-todoapp-tutorial.yml
@@ -7,7 +7,11 @@ env:
   DOTNET_VERSION: '10.0.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
-  DOTNET_CONFIGURATION: 'Release'
+  # Debug (not Release): this is a build-only compile sanity check, never published/shipped.
+  # Release builds pointlessly enable IL trimming/AOT machinery on some sample heads (see
+  # https://github.com/CommunityToolkit/Datasync/issues/521), so all sample CI workflows build
+  # Debug to avoid that overhead consistently, even where it isn't currently an issue.
+  DOTNET_CONFIGURATION: 'Debug'
   ServerProjectFile: 'samples/todoapp-tutorial/ServerApp/ServerApp.csproj'
   # ClientApp is a WPF project targeting net10.0-windows, so it is built on a windows-latest
   # runner in a separate job below. See https://github.com/CommunityToolkit/Datasync/issues/510.

--- a/.github/workflows/build-samples-todoapp-uno.yml
+++ b/.github/workflows/build-samples-todoapp-uno.yml
@@ -16,7 +16,11 @@ env:
   DOTNET_VERSION: '10.0.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
-  DOTNET_CONFIGURATION: 'Release'
+  # Debug (not Release): this is a build-only compile sanity check, never published/shipped.
+  # Release builds pointlessly enable IL trimming/AOT machinery on some sample heads (see
+  # https://github.com/CommunityToolkit/Datasync/issues/521), so all sample CI workflows build
+  # Debug to avoid that overhead consistently, even where it isn't currently an issue.
+  DOTNET_CONFIGURATION: 'Debug'
   # TodoApp.Uno.csproj is a single Uno.Sdk project with a multi-head TargetFrameworks list
   # (net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-windows10.0.26100;
   # net10.0-browserwasm;net10.0-desktop). No single runner can build every head (mobile heads

--- a/.github/workflows/build-samples-todoapp-windows.yml
+++ b/.github/workflows/build-samples-todoapp-windows.yml
@@ -7,7 +7,11 @@ env:
   DOTNET_VERSION: '10.0.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
-  DOTNET_CONFIGURATION: 'Release'
+  # Debug (not Release): this is a build-only compile sanity check, never published/shipped.
+  # Release builds pointlessly enable IL trimming/AOT machinery on some sample heads (see
+  # https://github.com/CommunityToolkit/Datasync/issues/521), so all sample CI workflows build
+  # Debug to avoid that overhead consistently, even where it isn't currently an issue.
+  DOTNET_CONFIGURATION: 'Debug'
   # WinUI3 declares <Platforms>x86;x64;ARM64</Platforms> with no AnyCPU, so Platform must be
   # specified explicitly - the CLI default of AnyCPU is not a valid configuration for this project.
   WinUI3ProjectFile: 'samples/todoapp/TodoApp.WinUI3/TodoApp.WinUI3.csproj'

--- a/samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia.Android/TodoApp.Avalonia.Android.csproj
+++ b/samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia.Android/TodoApp.Avalonia.Android.csproj
@@ -9,6 +9,19 @@
         <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
         <AndroidPackageFormat>apk</AndroidPackageFormat>
         <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
+
+        <!--
+          Mobile target frameworks (including net10.0-android) enable the IL trim analyzer during
+          `dotnet build` (not just `dotnet publish`) by SDK default. This CI pipeline only ever runs
+          `dotnet build` (see build-samples-todoapp-avalonia.yml) - it never publishes with
+          PublishTrimmed, so no actual IL trimming/linking happens here; the analyzer is purely
+          diagnostic noise on framework APIs (Avalonia's BindingPlugins.DataValidators, EF Core's
+          DbContext(DbContextOptions) ctor) that their own maintainers have marked
+          [RequiresUnreferencedCode]. Setting this also sets EnableTrimAnalyzer=false (see
+          Microsoft.NET.ILLink.targets), which disables the analyzer pass itself, not just its
+          warning output. See https://github.com/CommunityToolkit/Datasync/issues/521.
+        -->
+        <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia.iOS/TodoApp.Avalonia.iOS.csproj
+++ b/samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia.iOS/TodoApp.Avalonia.iOS.csproj
@@ -4,6 +4,19 @@
         <TargetFramework>net10.0-ios</TargetFramework>
         <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
         <Nullable>enable</Nullable>
+
+        <!--
+          net10.0-ios enables the IL trim analyzer during `dotnet build` (not just `dotnet publish`),
+          because iOS app projects are marked trimmable by the SDK by default. This CI pipeline only
+          ever runs `dotnet build` (see build-samples-todoapp-avalonia.yml) - it never publishes with
+          PublishTrimmed, so no actual IL trimming/linking happens here; the analyzer is purely
+          diagnostic noise on framework APIs (Avalonia's BindingPlugins.DataValidators, EF Core's
+          DbContext(DbContextOptions) ctor) that their own maintainers have marked
+          [RequiresUnreferencedCode]. Setting this also sets EnableTrimAnalyzer=false (see
+          Microsoft.NET.ILLink.targets), which disables the analyzer pass itself, not just its
+          warning output. See https://github.com/CommunityToolkit/Datasync/issues/521.
+        -->
+        <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
     </PropertyGroup>
 
     <ItemGroup>

--- a/samples/todoapp/TodoApp.MAUI/TodoApp.MAUI.csproj
+++ b/samples/todoapp/TodoApp.MAUI/TodoApp.MAUI.csproj
@@ -29,6 +29,20 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
+
+    <!--
+      net10.0-ios enables the IL trim analyzer during `dotnet build` (not just `dotnet publish`),
+      because iOS app projects are marked trimmable by the SDK by default. This CI pipeline only
+      ever runs `dotnet build` (see build-samples-todoapp-maui.yml) - it never publishes with
+      PublishTrimmed, so no actual IL trimming/linking happens here; the analyzer is purely
+      diagnostic noise on framework APIs (e.g. EF Core's DbContext(DbContextOptions) ctor) that
+      their own maintainers have marked [RequiresUnreferencedCode]. Setting this also sets
+      EnableTrimAnalyzer=false (see Microsoft.NET.ILLink.targets), which disables the analyzer
+      pass itself, not just its warning output. Scoped to the iOS TFM only, since the
+      Android/Windows heads haven't been confirmed to surface this warning.
+      See https://github.com/CommunityToolkit/Datasync/issues/521.
+    -->
+    <SuppressTrimAnalysisWarnings Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">true</SuppressTrimAnalysisWarnings>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Fixes #521.

`net10.0-ios` (and mobile TFMs generally) enable the IL trim analyzer during `dotnet build` — not just `dotnet publish` — because these SDKs mark projects trimmable by default. This surfaced `IL2026`/`IL2104` warnings on the `TodoApp.Avalonia.iOS` build (surfaced by the mobile CI added in #511 / PR #519), pointing at documented, trim-unsafe framework APIs:

- Avalonia's `BindingPlugins.DataValidators` (inherently reflection-based, by design)
- EF Core's `DbContext(DbContextOptions)` constructor (explicitly documented as not fully trim-compatible: https://aka.ms/efcore-docs-trimming)

Neither is a bug in the sample code — both are idiomatic, documented usage of their respective frameworks, exactly as taught in `docs/samples/todoapp/avalonia.md`.

## Why suppress rather than fix the code

This repo's CI only ever runs `dotnet build` for these samples (see `build-samples-todoapp-avalonia.yml` / `build-samples-todoapp-maui.yml`) — never `dotnet publish -p:PublishTrimmed=true`. So today, trim analysis on these projects is purely diagnostic noise: no actual IL trimming/linking ever happens, and no app is shipped from this pipeline. Avoiding the flagged APIs would mean fighting Avalonia/EF Core's own recommended patterns for the sake of a warning with no functional consequence in a build-only pipeline, and would make the samples worse as teaching examples.

## Changes

Added `<SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>`:

- `samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia.iOS/TodoApp.Avalonia.iOS.csproj` — the confirmed, reported case.
- `samples/todoapp/TodoApp.Avalonia/TodoApp.Avalonia.Android/TodoApp.Avalonia.Android.csproj` — same shared code path (`App.axaml.cs` / `AppDbContext.cs`) is compiled under this TFM too; added precautionarily even though Android didn't surface the warning in the CI run that filed the issue.
- `samples/todoapp/TodoApp.MAUI/TodoApp.MAUI.csproj` — scoped to the `net10.0-ios` TFM only (via the `GetTargetPlatformIdentifier` conditional pattern already used elsewhere in this file), since the Android/Windows heads weren't confirmed to have the warning.

Each edit includes a comment explaining the root cause and linking back to #521.

### Bonus: this also avoids the analyzer's build-time cost, not just its warning output

Per the actual `Microsoft.NET.ILLink.targets` shipped in the SDK:

```xml
<PropertyGroup Condition="'$(SuppressTrimAnalysisWarnings)' == 'true'">
  <_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) --notrimwarn</_ExtraTrimmerArgs>
  <EnableTrimAnalyzer Condition="'$(EnableTrimAnalyzer)' == ''">false</EnableTrimAnalyzer>
</PropertyGroup>
```

Setting `SuppressTrimAnalysisWarnings=true` also sets `EnableTrimAnalyzer=false` (since we don't set `EnableTrimAnalyzer` explicitly ourselves), which disables the analyzer pass itself rather than merely hiding its output. Separately, the actual `ILLink` linking task (the potentially slow part) is only ever wired into the `publish` pipeline, not `build` — so it was never running here in the first place.

## Testing

- `dotnet build` on the shared `TodoApp.Avalonia.csproj` and `TodoApp.Avalonia.Desktop.csproj` — succeeded (1 pre-existing, unrelated nullable warning).
- `dotnet restore` / `dotnet build --configuration Release` on `Datasync.Toolkit.sln` — succeeded, 0 warnings/0 errors. (This solution doesn't include the edited sample projects, confirming no impact on the core library.)
- `dotnet test Datasync.Toolkit.sln --configuration Release` — `CommunityToolkit.Datasync.Client.Test`: 1432/1432 passed. `CommunityToolkit.Datasync.Server.Test` had pre-existing, environment-only failures (no local Docker daemon; that suite depends on TestContainers) — confirmed identical failure count with the changes stashed out, so unrelated to this PR.
- Could not locally build the actual `net10.0-ios` / MAUI-iOS heads to visually confirm the warnings disappear (no Xcode/iOS workload available locally) — deferred to this repo's CI, which pins the exact Xcode/workload versions that originally surfaced the warnings.

## Related

- #511 / #519 — Phase 3 samples CI rollout, where this was surfaced.
