### PR TITLE
fix: resolve TodoApp.Uno Skia build failures and bump Uno Platform 5 -> 6

### DIFF
--- a/.github/workflows/build-samples-todoapp-uno.yml
+++ b/.github/workflows/build-samples-todoapp-uno.yml
@@ -1,14 +1,5 @@
 name: Build Sample - TodoApp Uno
 
-# NOTE: This workflow is NOT currently wired into build-samples.yml. #506 fixed the NU1605
-# restore blocker that used to affect every head (see samples/todoapp/TodoApp.Uno/global.json),
-# so restore now succeeds everywhere. However, build now fails on every Skia-based head (android,
-# ios, maccatalyst, browserwasm, desktop) with UXAML0001/CS1061 (EventTriggerBehavior could not
-# be found) - see the `desktop` job below for details and
-# https://github.com/CommunityToolkit/Datasync/issues/506 for background. Re-add the
-# `todoapp-uno` job to build-samples.yml (and to all-samples-built's `needs`) once that build
-# failure is resolved and every head restores AND builds cleanly.
-
 on:
   workflow_call:
 
@@ -145,27 +136,6 @@ jobs:
           --no-restore
 
   desktop:
-    # NOTE: this head (along with every other Skia-based head in this file - android,
-    # ios-maccatalyst, browserwasm) currently fails to BUILD (not restore) with:
-    #   error UXAML0001: The type {using:Microsoft.Xaml.Interactions.Core}EventTriggerBehavior
-    #   could not be found
-    # CommunityToolkit.WinUI.Behaviors 8.2.250402 resolves
-    # Uno.Microsoft.Xaml.Behaviors.Interactivity.WinUI 3.0.0-dev.17.g7c09b9114d on Skia heads
-    # (confirmed via project.assets.json for desktop and browserwasm), which appears to lack the
-    # Microsoft.Xaml.Interactions.Core types used in Views/TodoListPage.xaml. The `windows` job
-    # below is unaffected - it resolves the real Microsoft.Xaml.Behaviors.WinUI.Managed 3.0.0
-    # package instead. This is a separate, pre-existing bug from the NU1903 Tmds.DBus finding
-    # below and from the NU1605 restore blocker #506 originally hit (now fixed - see
-    # samples/todoapp/TodoApp.Uno/global.json) - it was never surfaced before because restore
-    # always failed first. Tracked as a #506 follow-up issue.
-    #
-    # Restore also emits a NU1903 warning for 'Tmds.DBus' 0.16.0 (GHSA-xrw6-gwf8-vvr9 /
-    # CVE-2026-39959), floated transitively via Uno.WinUI.Runtime.Skia.X11. This is harmless as a
-    # CI matter today (this repo does not configure NuGet audit to fail on warnings) but is not
-    # yet resolved - Uno only switches Uno.WinUI.Runtime.Skia.X11 to the patched
-    # Tmds.DBus.Protocol starting at Uno.WinUI 6.0.465, which requires a major-version bump of
-    # Uno.Sdk. See https://github.com/CommunityToolkit/Datasync/issues/506 for background and the
-    # tracked major-version-bump follow-up issue.
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/build-samples.yml
+++ b/.github/workflows/build-samples.yml
@@ -37,20 +37,8 @@ jobs:
   todoapp-maui:
     uses: ./.github/workflows/build-samples-todoapp-maui.yml
 
-  # NOTE: todoapp-uno (build-samples-todoapp-uno.yml) is intentionally NOT wired in here yet.
-  # #506 fixed the NU1605 restore blocker that used to affect every head (bumped Uno.Sdk in
-  # samples/todoapp/TodoApp.Uno/global.json from 5.4.5 to 5.6.54), so TodoApp.Uno.csproj now
-  # restores cleanly. However, restoring cleanly surfaced a separate, pre-existing bug: on every
-  # Skia-based head (android, ios, maccatalyst, browserwasm, desktop - confirmed for desktop and
-  # browserwasm; android/ios/maccatalyst require workloads not available where this was
-  # verified), CommunityToolkit.WinUI.Behaviors 8.2.250402 resolves
-  # Uno.Microsoft.Xaml.Behaviors.Interactivity.WinUI 3.0.0-dev.17.g7c09b9114d instead of the real
-  # Microsoft.Xaml.Behaviors.WinUI.Managed package (which the windows head still gets), and that
-  # substitute is missing the Microsoft.Xaml.Interactions.Core types used in
-  # Views/TodoListPage.xaml, so build fails with UXAML0001/CS1061 (EventTriggerBehavior could not
-  # be found). This was never surfaced before because restore always failed first. See the
-  # tracking issue for this build failure (filed as a #506 follow-up) - re-add this job once
-  # that's resolved and every head restores AND builds cleanly.
+  todoapp-uno:
+    uses: ./.github/workflows/build-samples-todoapp-uno.yml
 
   # Single aggregation point so branch protection only needs to require one check,
   # regardless of how many sample workflows are added over time.
@@ -66,6 +54,7 @@ jobs:
       - todoapp-avalonia
       - todoapp-windows
       - todoapp-maui
+      - todoapp-uno
     runs-on: ubuntu-latest
     steps:
       - name: Check sample build results

--- a/samples/todoapp/TodoApp.Uno/TodoApp.Uno/Platforms/Android/Main.Android.cs
+++ b/samples/todoapp/TodoApp.Uno/TodoApp.Uno/Platforms/Android/Main.Android.cs
@@ -8,8 +8,6 @@ using Android.OS;
 using Android.Runtime;
 using Android.Views;
 using Android.Widget;
-using Com.Nostra13.Universalimageloader.Core;
-using Microsoft.UI.Xaml.Media;
 
 namespace TodoApp.Uno.Droid;
 [global::Android.App.ApplicationAttribute(
@@ -25,19 +23,9 @@ public class Application : Microsoft.UI.Xaml.NativeApplication
     public Application(IntPtr javaReference, JniHandleOwnership transfer)
         : base(() => new App(), javaReference, transfer)
     {
-        ConfigureUniversalImageLoader();
-    }
-
-    private static void ConfigureUniversalImageLoader()
-    {
-        // Create global configuration and initialize ImageLoader with this config
-        ImageLoaderConfiguration config = new ImageLoaderConfiguration
-            .Builder(Context)
-            .Build();
-
-        ImageLoader.Instance.Init(config);
-
-        ImageSource.DefaultImageLoader = ImageLoader.Instance.LoadImageAsync;
+        // Uno Platform 6.0 handles image loading entirely with the Skia Rendering mode, so the
+        // UniversalImageLoader configuration previously required here has been removed.
+        // See https://platform.uno/docs/articles/migrating-to-uno-6.html.
     }
 }
 

--- a/samples/todoapp/TodoApp.Uno/TodoApp.Uno/Platforms/Desktop/Program.cs
+++ b/samples/todoapp/TodoApp.Uno/TodoApp.Uno/Platforms/Desktop/Program.cs
@@ -1,4 +1,4 @@
-using Uno.UI.Runtime.Skia;
+using Uno.UI.Hosting;
 
 namespace TodoApp.Uno;
 public class Program
@@ -6,12 +6,12 @@ public class Program
     [STAThread]
     public static void Main(string[] args)
     {
-        var host = SkiaHostBuilder.Create()
+        var host = UnoPlatformHostBuilder.Create()
             .App(() => new App())
             .UseX11()
             .UseLinuxFrameBuffer()
             .UseMacOS()
-            .UseWindows()
+            .UseWin32()
             .Build();
 
         host.Run();

--- a/samples/todoapp/TodoApp.Uno/TodoApp.Uno/Views/TodoListPage.xaml
+++ b/samples/todoapp/TodoApp.Uno/TodoApp.Uno/Views/TodoListPage.xaml
@@ -9,20 +9,12 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:viewmodels="using:TodoApp.Uno.ViewModels"
       xmlns:controls="using:Microsoft.UI.Xaml.Controls"
-      xmlns:interactions="using:Microsoft.Xaml.Interactions.Core"
       xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
       xmlns:uen="using:Uno.Extensions.Navigation.UI"
       xmlns:utu="using:Uno.Toolkit.UI"
       NavigationCacheMode="Required"
       Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
       mc:Ignorable="d">
-
-  <!-- Interaction below binds to the command correctly, but the event is not triggered. Handling in code behind for now -->
-  <interactivity:Interaction.Behaviors>
-    <interactions:EventTriggerBehavior EventName="Loaded">
-      <interactions:InvokeCommandAction Command="{x:Bind ViewModel.LoadPageCommand}" />
-    </interactions:EventTriggerBehavior>
-  </interactivity:Interaction.Behaviors>
 
   <Page.Resources>
     <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />

--- a/samples/todoapp/TodoApp.Uno/global.json
+++ b/samples/todoapp/TodoApp.Uno/global.json
@@ -1,14 +1,18 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
-  // Bumped from 5.4.5 (-> Uno.WinUI 5.4.22) to 5.6.54 (-> Uno.WinUI 5.6.99) to resolve NU1605:
-  // CommunityToolkit.WinUI.Behaviors 8.2.250402 floors Uno.WinUI at >= 5.5.87, which is higher
-  // than what Uno.Sdk 5.4.5 resolves, causing a package-downgrade restore error on every head.
-  // This does NOT resolve the separate NU1903 (Tmds.DBus 0.16.0) advisory on the desktop head -
-  // Uno.WinUI.Runtime.Skia.X11 keeps floating vulnerable Tmds.DBus 0.16.0 through the entire
-  // 5.x line and only switches to the patched Tmds.DBus.Protocol starting at Uno.WinUI 6.0.465.
-  // See https://github.com/CommunityToolkit/Datasync/issues/506.
+  // Bumped from 5.6.54 (-> Uno.WinUI 5.6.99) to 6.5.36 (-> Uno.WinUI 6.5.237). See #524:
+  // this major-version bump resolves the NU1903 (Tmds.DBus 0.16.0, GHSA-xrw6-gwf8-vvr9) advisory
+  // on the desktop head for free - Uno.WinUI.Runtime.Skia.X11 switches to the patched
+  // Tmds.DBus.Protocol dependency starting at Uno.WinUI 6.0.465, and 6.5.237 resolves well above
+  // that floor. It also lifts the Uno.Wasm.Bootstrap net9.0+ TargetFramework guard blocking the
+  // browserwasm head (Uno.Sdk 6.x implicitly resolves Uno.Wasm.Bootstrap 10.0.96 instead of the
+  // 5.x line's 8.0.23). See https://platform.uno/docs/articles/migrating-to-uno-6.html for the
+  // accompanying manual code changes required across heads (Platforms/Desktop/Program.cs,
+  // Platforms/Android/Main.Android.cs).
+  // See https://github.com/CommunityToolkit/Datasync/issues/506 and
+  // https://github.com/CommunityToolkit/Datasync/issues/524.
   "msbuild-sdks": {
-    "Uno.Sdk": "5.6.54"
+    "Uno.Sdk": "6.5.36"
   },
   "sdk":{
     "allowPrerelease": false


### PR DESCRIPTION
## Summary

Fixes the `TodoApp.Uno` sample's build failures on Skia-based heads (android, ios, maccatalyst, browserwasm, desktop), and bumps `Uno.Sdk` 5 -> 6, which resolves two outstanding `NU1903` advisories along the way.

Closes #525
Closes #524
Closes #526

## What's in here

### #525 - `EventTriggerBehavior` / `UXAML0001`

`Views/TodoListPage.xaml` used an `EventTriggerBehavior`/`InvokeCommandAction` pair (from `Microsoft.Xaml.Interactions.Core`) to fire `LoadPageCommand` on `Loaded`. This behavior was already **dead code** - its own comment says *"the event is not triggered. Handling in code behind for now"*, and `TodoListPage.xaml.cs`'s `DataContextChangedHandler` already calls `ViewModel.LoadPageCommand.ExecuteAsync(null)` directly.

On every non-Windows (Skia) head, `CommunityToolkit.WinUI.Behaviors` resolves `Uno.Microsoft.Xaml.Behaviors.Interactivity.WinUI` instead of the real `Microsoft.Xaml.Behaviors.WinUI.Managed`. I confirmed via NuGet (across every released version, prerelease and stable, including the latest `8.2.251219` `CommunityToolkit.WinUI.Behaviors`) that the Uno port ([`unoplatform/Uno.XamlBehaviors`](https://github.com/unoplatform/Uno.XamlBehaviors)) only ever ships `Microsoft.Xaml.Interactivity` (the base attached-property infrastructure) - it has never shipped a `Microsoft.Xaml.Interactions` (Core triggers/actions) equivalent. So option 1 from the issue (pin a different version) was a dead end; the fix is to remove the dead behavior block and its now-unused `xmlns:interactions` namespace.

### #524 - Uno Platform 5 -> 6

Bumped `Uno.Sdk` in `global.json` from `5.6.54` to `6.5.36` (-> `Uno.WinUI 6.5.237`). This was necessary, not optional: once the #525 fix let the `browserwasm` head's build get past the XAML compile stage, it hit a new (previously-masked) failure - `Uno.Wasm.Bootstrap 8.0.23` (floored by Uno.WinUI 5.x) hard-rejects any project targeting `TargetFrameworkVersion >= 9.0`. Uno.Sdk 6.x resolves `Uno.Wasm.Bootstrap 10.0.96` instead, which lifts that guard.

Required manual migration per the [Uno 6 migration guide](https://platform.uno/docs/articles/migrating-to-uno-6.html):
- `Platforms/Desktop/Program.cs`: `Uno.UI.Runtime.Skia` -> `Uno.UI.Hosting`, `SkiaHostBuilder` -> `UnoPlatformHostBuilder`, `.UseWindows()` -> `.UseWin32()`.
- `Platforms/Android/Main.Android.cs`: removed the `UniversalImageLoader` configuration - Uno 6 now handles image loading internally via Skia rendering.

### #526 - `System.Security.Cryptography.Xml` NU1903 (browserwasm)

Resolved as a side effect of the #524 bump: `System.Security.Cryptography.Xml` now resolves to `10.0.7` (up from the vulnerable `8.0.2`) on the `browserwasm` head, confirmed via a clean `dotnet restore` with no `NU1903` warnings.

As a bonus, the bump also resolves the original `Tmds.DBus` `NU1903` finding from #506 on the `desktop` head (`Uno.WinUI.Runtime.Skia.X11` switches to the patched `Tmds.DBus.Protocol` starting at `Uno.WinUI 6.0.465`).

### CI

Re-enabled the `todoapp-uno` job (all 5 heads) in `build-samples.yml`, and removed the stale "disabled pending fix" comments in both workflow files.

## Verification

Verified locally:
- `desktop`: `dotnet restore` + `dotnet build` clean, no workload required.
- `browserwasm`: `dotnet restore` + `dotnet build` clean, after installing the `wasm-tools` workload (into a separate user-writable .NET SDK, since the system-wide SDK install wasn't writable in my environment). No `NU1903` warnings on restore (confirms #526).
- Root `Datasync.Toolkit.sln` (main library, unaffected by this change) still restores and builds clean.

Not verified locally (relying on CI for these, same limitation noted by the original issue reports):
- `android`: the `android` workload installs, but the Android SDK (platform-tools/build-tools) wasn't provisioned in my environment, so the build fails before reaching any application code.
- `ios` / `maccatalyst`: require a full Xcode install (only Command Line Tools available in my environment).
- `windows`: requires a Windows runner.