### PR TITLE
docs: align client runtime version in offline guide

### DIFF
--- a/docs/in-depth/client/index.md
+++ b/docs/in-depth/client/index.md
@@ -1,6 +1,6 @@
 # Creating offline clients
 
-This guide shows you how to perform common scenarios using the Datasync Community Toolkit.  Use the client library in any .NET 9 application, including AvaloniaUI, MAUI, Uno Platform, WinUI, and WPF applications.
+This guide shows you how to perform common scenarios using the Datasync Community Toolkit.  Use the client library in any .NET 10.x or later application, including AvaloniaUI, MAUI, Uno Platform, WinUI, and WPF applications.
 
 !!! note "Blazor WASM and Blazor Hybrid"
     The offline capabilities are known to have issues with Blazor WASM and Blazor Hybrid (since EF Core and SQLite do not work in those environments when running in the browser).  Use online-only operations in these environments.  For more information, see [our guide on Blazor WASM](./advanced/blazor-wasm.md)


### PR DESCRIPTION
Fixes #545\n\n## Summary\n- update the offline client guide to say .NET 10.x or later\n- align the version text with the current README requirement\n\n## Validation\n- searched  for remaining  references