### PR TITLE
fix: suppress IL2026/IL2104/IL2121 trim analysis warnings on TodoApp.Uno browserwasm/ios/maccatalyst

### DIFF
--- a/samples/todoapp/TodoApp.Uno/TodoApp.Uno/TodoApp.Uno.csproj
+++ b/samples/todoapp/TodoApp.Uno/TodoApp.Uno/TodoApp.Uno.csproj
@@ -41,6 +41,17 @@
     </UnoFeatures>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 
+    <!--
+      IL trim analyzer runs during `dotnet build` on these TFMs (SDK marks them trimmable by
+      default), but this CI pipeline never publishes with PublishTrimmed, so it's diagnostic
+      noise only. Same fix as #531. See #534.
+    -->
+    <SuppressTrimAnalysisWarnings Condition="
+        $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' OR
+        $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst' OR
+        $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'browserwasm'
+      ">true</SuppressTrimAnalysisWarnings>
+
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Assets\AddItem.png" />


### PR DESCRIPTION
## Summary

Now that #533 fixes the `TodoApp.Uno` build failure, the `browserwasm`, `ios`, and `maccatalyst` heads build successfully in CI for the first time - and surface IL trim-analyzer warnings (IL2026/IL2104/IL2121) that were previously masked by the build failure. `dotnet build` enables the trim analyzer on these SDKs by default, but this CI pipeline only ever runs `dotnet build`, never `dotnet publish -p:PublishTrimmed=true`, so the warnings are diagnostic noise on framework APIs (EF Core's `DbContext` ctor, `JsonSerializer.Serialize`, Uno's own `Hosting`/`Navigation` surface and source-generated `BindableMetadata.g.cs`), not bugs in the sample.

Same fix pattern as #531 (`TodoApp.Avalonia`/`TodoApp.MAUI`): add `SuppressTrimAnalysisWarnings`, scoped via the same `GetTargetPlatformIdentifier`-conditional pattern already used in `TodoApp.MAUI.csproj`, to the three confirmed-affected TFMs.

`android`/`desktop`/`windows` did not surface these warnings in the CI run linked from the issue, so they are intentionally left unsuppressed for now.

Fixes #534

## Verification

- `net10.0-desktop`: `dotnet restore`/`build` clean, no workload required - confirms the change doesn't regress unrelated heads.
- `net10.0-browserwasm`: `dotnet restore`/`build` clean after installing the `wasm-tools` workload into a separate user-writable .NET SDK (system-wide SDK is root-owned in this environment).
  - **Negative control**: reverted the fix and rebuilt clean -> IL2026/IL2104/IL2121 appeared **18 times**. Restored the fix and rebuilt clean -> **0** occurrences, build still succeeded. Confirms the suppression is actually responsible for the fix, not incidental.
- Root `Datasync.Toolkit.sln` (unaffected by this change, `TodoApp.Uno` isn't part of it): restores/builds clean. `CommunityToolkit.Datasync.Client.Test` passes 1432/1432. `CommunityToolkit.Datasync.Server.Test` Live DB suites (AzureSQL/PgSQL/MongoDB/CosmosDB) fail in this sandbox due to no Docker daemon - a pre-existing environment limitation unrelated to this change.

Not verified locally (relying on CI, same limitation noted in #531/#533):
- `ios`/`maccatalyst`: require a full Xcode install (only Command Line Tools available here).
- `android`: requires the Android SDK/workload.
- `windows`: requires a Windows runner.