### PR TITLE
fix: resolve CS1574 unresolved DatabaseFacade/ChangeTracker doc crefs in sample DbContexts (#539)

### DIFF
--- a/samples/todoapp-blazor-wasm/TodoApp.BlazorWasm.Server/Database/TodoContext.cs
+++ b/samples/todoapp-blazor-wasm/TodoApp.BlazorWasm.Server/Database/TodoContext.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace TodoApp.BlazorWasm.Server.Database;
 

--- a/samples/todoapp/TodoApp.Uno/TodoApp.Uno/Database/AppDbContext.cs
+++ b/samples/todoapp/TodoApp.Uno/TodoApp.Uno/Database/AppDbContext.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace TodoApp.Uno.Database;
 

--- a/samples/todoapp/TodoApp.WPF/Database/AppDbContext.cs
+++ b/samples/todoapp/TodoApp.WPF/Database/AppDbContext.cs
@@ -7,6 +7,7 @@
 using CommunityToolkit.Datasync.Client.Http;
 using CommunityToolkit.Datasync.Client.Offline;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using TodoApp.WPF.Services;
 
 namespace TodoApp.WPF.Database;

--- a/samples/todoapp/TodoApp.WinUI3/Database/AppDbContext.cs
+++ b/samples/todoapp/TodoApp.WinUI3/Database/AppDbContext.cs
@@ -7,6 +7,7 @@
 using CommunityToolkit.Datasync.Client.Http;
 using CommunityToolkit.Datasync.Client.Offline;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using System;
 using System.Linq;
 using System.Threading;


### PR DESCRIPTION
## Summary

Fixes #539.

Several sample `DbContext`/initializer classes have XML doc `<see cref="..."/>` tags that reference EF Core types (`DatabaseFacade`, `ChangeTracker`) which live in sub-namespaces (`Microsoft.EntityFrameworkCore.Infrastructure`, `Microsoft.EntityFrameworkCore.ChangeTracking`) not covered by the file's `using Microsoft.EntityFrameworkCore;` import. The C# compiler can't resolve the `cref` without the type in scope, producing CS1574 warnings:

```
warning CS1574: XML comment has cref attribute 'EnsureCreated' that could not be resolved
```

This only reliably surfaces on TFMs/SDKs that enable XML doc-comment analysis by default (e.g. `Microsoft.Android.Sdk`, as seen in the linked CI run for `TodoApp.Uno`), but the underlying missing-using bug is present regardless of head, and reproduces on any TFM once `GenerateDocumentationFile` is turned on.

The issue reported only `TodoApp.Uno`, but the same bug pattern exists in `TodoApp.WPF`, `TodoApp.WinUI3`, and `TodoApp.BlazorWasm.Server` — `TodoApp.Avalonia` already has the correct import, which is the pattern this PR applies elsewhere.

## Changes

Added the missing `using` directive(s) so the doc `cref`s resolve, matching the existing correct pattern in `TodoApp.Avalonia/Database/DbContextInitializer.cs`:

| File | Added usings | cref(s) fixed |
|---|---|---|
| `samples/todoapp/TodoApp.Uno/TodoApp.Uno/Database/AppDbContext.cs` | `Microsoft.EntityFrameworkCore.Infrastructure` | `DatabaseFacade.EnsureCreated` |
| `samples/todoapp/TodoApp.WPF/Database/AppDbContext.cs` | `Microsoft.EntityFrameworkCore.Infrastructure` | `DatabaseFacade.EnsureCreated` |
| `samples/todoapp/TodoApp.WinUI3/Database/AppDbContext.cs` | `Microsoft.EntityFrameworkCore.Infrastructure` | `DatabaseFacade.EnsureCreated` |
| `samples/todoapp-blazor-wasm/TodoApp.BlazorWasm.Server/Database/TodoContext.cs` | `Microsoft.EntityFrameworkCore.ChangeTracking`, `Microsoft.EntityFrameworkCore.Infrastructure` | `DatabaseFacade.EnsureCreatedAsync`, `ChangeTracker.Clear` |

No behavior changes — doc-comment-only fix.

## Verification

- Reproduced the exact reported warning by temporarily reverting the `TodoApp.Uno` change and building `net10.0-desktop` with `-p:GenerateDocumentationFile=true`; re-applying the fix removes the warning (0 errors, 0 CS1574).
- Built `TodoApp.BlazorWasm.Server` (`net10.0`) with `-p:GenerateDocumentationFile=true`; confirmed `DatabaseFacade.EnsureCreatedAsync` and `ChangeTracker.Clear` no longer emit CS1574.
- `TodoApp.WPF` / `TodoApp.WinUI3` are Windows-only TFMs and could not be built in my (macOS) environment — same limitation noted by @nightcityblade in the issue thread. The fix is a mechanical one-line addition identical to the verified Uno/BlazorWasm fixes and the existing working Avalonia precedent.
- `dotnet build Datasync.Toolkit.sln -c Release`: 0 warnings, 0 errors (core solution doesn't reference sample projects — confirms this change is fully isolated to `samples/`).
- `dotnet test Datasync.Toolkit.sln -c Release --no-build`: `CommunityToolkit.Datasync.Client.Test` 1432/1432 passed. `CommunityToolkit.Datasync.Server.Test` failures are pre-existing `DockerUnavailableException` (no local Docker daemon in this environment) per the repo's TestContainers-based test setup, unrelated to this change.

## Follow-ups (filed separately, not in this PR)

- Unrelated pre-existing CS1574 warnings in `TodoApp.BlazorWasm.Client` (`ValidationException`, `ConcurrencyException`, generic-method overload crefs like `AddAsync(T)`) — different root cause (ambiguous/overload cref resolution).
- `TodoContext.cs`'s `<see cref="EntityFrameworkQueryableExtensions.AnyAsync{TSource}(IQueryable{TSource})"/>` still doesn't resolve because the cref's parameter list omits the `CancellationToken` overload parameter.