### PR TITLE
fix: replace obsolete EnableHotReload with UseStudio in TodoApp.Uno

### DIFF
--- a/samples/todoapp/TodoApp.Uno/TodoApp.Uno/App.xaml.cs
+++ b/samples/todoapp/TodoApp.Uno/TodoApp.Uno/App.xaml.cs
@@ -54,7 +54,7 @@ public partial class App : Application
         MainWindow = builder.Window;
 
 #if DEBUG
-        MainWindow.EnableHotReload();
+        MainWindow.UseStudio();
 #endif
         MainWindow.SetWindowIcon();
 


### PR DESCRIPTION
## Summary

`App.xaml.cs` calls the now-obsolete `WindowExtensions.EnableHotReload(Window)` API, producing a `UNO0008` warning on every `todoapp-uno / *` CI job build.

## Fix

Per [UNO0008](https://aka.platform.uno/UNO0008), Uno Platform 5.5+ deprecated `Window.EnableHotReload()` for `Uno.Sdk`-style projects (which `TodoApp.Uno.csproj` already is) in favor of `Window.UseStudio()` — a drop-in, same-signature replacement. Uno's own solution templates use exactly this pattern (`MainWindow.UseStudio();` inside `#if DEBUG`).

```diff
 #if DEBUG
-        MainWindow.EnableHotReload();
+        MainWindow.UseStudio();
 #endif
```

Low risk, purely a hot-reload developer-experience API swap with no runtime behavior change for a normal (non-hot-reload) build/run.

## Testing

- `dotnet restore samples/todoapp/TodoApp.Uno/TodoApp.Uno/TodoApp.Uno.csproj -p:TargetFramework=net10.0-desktop`
- `dotnet build samples/todoapp/TodoApp.Uno/TodoApp.Uno/TodoApp.Uno.csproj -f net10.0-desktop --configuration Debug --no-restore`
  - Build succeeded, 0 errors, and the `UNO0008` warning no longer appears.
  - Remaining warnings (NU1510 x3, CS8618 x2, CS8622, Uno0001) are pre-existing and unrelated to this change.
- Other heads (android/ios/maccatalyst/windows/browserwasm) not built locally (missing workloads/Xcode/Windows runner here); same code path executes on every head, so CI's `build-samples-todoapp-uno.yml` matrix will validate them on this PR.

Fixes #536