### PR TITLE
docs: fix CS1574 XML cref for AnyAsync

### DIFF
--- a/samples/todoapp-blazor-wasm/TodoApp.BlazorWasm.Server/Database/TodoContext.cs
+++ b/samples/todoapp-blazor-wasm/TodoApp.BlazorWasm.Server/Database/TodoContext.cs
@@ -57,7 +57,7 @@ public class TodoContext(DbContextOptions<TodoContext> options) : DbContext(opti
     /// This method performs the following operations:
     /// <list type="number">
     /// <item><description>Ensures the database is created using <see cref="DatabaseFacade.EnsureCreatedAsync"/>.</description></item>
-    /// <item><description>Checks if the TodoItems table is empty using <see cref="EntityFrameworkQueryableExtensions.AnyAsync{TSource}(IQueryable{TSource})"/>.</description></item>
+    /// <item><description>Checks if the TodoItems table is empty using <see cref="EntityFrameworkQueryableExtensions.AnyAsync{TSource}(IQueryable{TSource}, CancellationToken)"/>.</description></item>
     /// <item><description>If empty, clears the change tracker to avoid entity tracking conflicts.</description></item>
     /// <item><description>Adds three sample todo items with predefined titles.</description></item>
     /// <item><description>Saves the sample data to the database.</description></item>


### PR DESCRIPTION
## Summary

Fixes the unresolved XML documentation `cref` for `EntityFrameworkQueryableExtensions.AnyAsync` in `TodoContext`.

The documented overload includes a `CancellationToken` parameter, so the `cref` has been updated to match the actual method signature.

## Validation

- Built `TodoApp.BlazorWasm.Server.csproj` with XML documentation generation enabled.
- The CS1574 warning in `TodoContext.cs` no longer appears.

Closes #551