### PR TITLE
fix: enable compiled Source binding to resolve XamlC XC0025 in TodoApp.MAUI

### DIFF
--- a/samples/todoapp/TodoApp.MAUI/MainPage.xaml
+++ b/samples/todoapp/TodoApp.MAUI/MainPage.xaml
@@ -55,7 +55,7 @@
                         Completed="OnAddItemEntryCompleted"
                         Placeholder="Enter Todo Item Text"
                         ReturnCommand="{Binding AddItemCommand}"
-                        ReturnCommandParameter="{Binding Text, Source={x:Reference addItemEntry}}"
+                        ReturnCommandParameter="{Binding Text, Source={x:Reference addItemEntry}, x:DataType=Entry}"
                         Style="{StaticResource addItemEntry}" />
                 </Grid>
             </Border>

--- a/samples/todoapp/TodoApp.MAUI/TodoApp.MAUI.csproj
+++ b/samples/todoapp/TodoApp.MAUI/TodoApp.MAUI.csproj
@@ -43,6 +43,18 @@
       See https://github.com/CommunityToolkit/Datasync/issues/521.
     -->
     <SuppressTrimAnalysisWarnings Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">true</SuppressTrimAnalysisWarnings>
+
+    <!--
+      MainPage.xaml has one binding (Entry.ReturnCommandParameter) that sets an explicit
+      Source={x:Reference ...} instead of relying on the page's BindingContext. By default,
+      XamlC skips compiling any binding with an explicit Source, falling back to slower
+      reflection-based binding and emitting an XC0025 warning. Opting into this project-wide
+      flag lets XamlC compile that binding too, now that it's annotated with the correct
+      x:DataType for its Source (see MainPage.xaml). This project has no other Source-based
+      bindings, so there's no risk of newly-surfaced x:DataType mismatches elsewhere.
+      See https://github.com/CommunityToolkit/Datasync/issues/517.
+    -->
+    <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Fixes #517.

`MainPage.xaml`'s `Entry.ReturnCommandParameter` binds via an explicit `Source={x:Reference addItemEntry}` instead of the page's `BindingContext`. By default, XamlC skips compiling any binding with an explicit `Source`, which produced this build warning (performance-only, no functional impact):

```
MainPage.xaml(58,25): XamlC warning XC0025: Binding was not compiled because it has an explicitly set Source property and compilation of bindings with Source is not enabled. ...
```

## Fix

Per current [.NET MAUI docs on compiling `Source` bindings](https://learn.microsoft.com/dotnet/maui/fundamentals/data-binding/compiled-bindings#compile-bindings-that-define-the-source-property):

1. `TodoApp.MAUI.csproj`: opt in to `<MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>` project-wide, with a comment explaining why and confirming this is the only `Source`-based binding in the project (so there's no risk of newly-surfaced `x:DataType` mismatches elsewhere, per the doc's own caution about this being an opt-in feature).
2. `MainPage.xaml`: annotate the binding itself with the documented inline `x:DataType=Entry` so XamlC has the type info it needs to compile it: `{Binding Text, Source={x:Reference addItemEntry}, x:DataType=Entry}`.

This avoids any XAML restructuring — no `DataTemplate`/binding-scope changes needed, since MAUI 9+ supports annotating the `Binding` markup extension directly.

## Verification

Local verification wasn't possible (macOS host, no MAUI workloads installed, no Windows target available), so I triggered `build-samples.yml` manually via `workflow_dispatch` on the fork and inspected the raw job logs:

- `todoapp-windows / build` (the job that originally surfaced this warning): [run](https://github.com/adrianhall/CommunityToolkit-Datasync/actions/runs/29114526141) — **0 occurrences of `XC0025`** in the build log; only the pre-existing, unrelated `CS0618 ListView is obsolete` warning remains (same warning present before this change).
- `todoapp-maui / android` and `todoapp-maui / ios`: also clean — no `XC0025`, no new `XC00xx` warnings.
- All 18 jobs in the `build-samples.yml` run passed.

## Related

- #510 / #514 — where this warning was first surfaced when Windows CI coverage was added for `TodoApp.MAUI`.