### PR TITLE
fix: suppress NETSDK1198 missing win-AnyCPU.pubxml warning in TodoApp.Uno

### DIFF
--- a/samples/todoapp/TodoApp.Uno/Directory.Build.props
+++ b/samples/todoapp/TodoApp.Uno/Directory.Build.props
@@ -9,7 +9,10 @@
       NU1507: Warning when there are multiple package sources when using CPM with no source mapping
       NETSDK1201: Warning that specifying RID won't create self containing app
       PRI257: Ignore default language (en) not being one of the included resources (eg en-us, en-uk)
+      NETSDK1198: Warning that a win-AnyCPU.pubxml publish profile wasn't found. Triggered by Uno's
+        WinAppSDK/MSIX packaging pipeline during a plain build, even though this sample is never
+        actually published/packaged in CI (build-only, Debug-only CI pipeline).
     -->
-    <NoWarn>$(NoWarn);NU1507;NETSDK1201;PRI257</NoWarn>
+    <NoWarn>$(NoWarn);NU1507;NETSDK1201;PRI257;NETSDK1198</NoWarn>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

Adds `NETSDK1198` to the existing `<NoWarn>` list in `samples/todoapp/TodoApp.Uno/Directory.Build.props`, alongside `NU1507`, `NETSDK1201`, and `PRI257`.

## Root cause

Uno's WinAppSDK/MSIX packaging pipeline for the Windows head triggers a partial publish-profile lookup during a plain `dotnet build`, warning that a conventionally-named `win-AnyCPU.pubxml` publish profile is missing. This sample never publishes/packages in CI (Debug-only, build-only pipeline), so the profile isn't needed. This is the same class of noise already suppressed for `NETSDK1201` in the same file.

## Verification

Since this only reproduces on the `windows` head (Windows runner), I dispatched the `Build Samples` workflow (`workflow_dispatch`) on this branch in my fork and confirmed:

- `todoapp-uno / windows` job succeeded (build: 0 errors).
- The `NETSDK1198` warning about `win-AnyCPU.pubxml` no longer appears in the job log.
- No other warnings/errors were introduced; remaining warnings in that job (`MVVMTK0045`) are pre-existing and unrelated.
- Run: https://github.com/adrianhall/CommunityToolkit-Datasync/actions/runs/29145469398

Fixes #542