### PR TITLE
fix: remove redundant NU1510 PackageReference pins in TodoApp.Uno

### DIFF
--- a/samples/todoapp/TodoApp.Uno/Directory.Packages.props
+++ b/samples/todoapp/TodoApp.Uno/Directory.Packages.props
@@ -14,9 +14,6 @@
     <!-- Force the SQLitePCLRaw 3.x line to resolve NU1903 (GHSA-2m69-gcr7-jv3q) floated by CommunityToolkit.Datasync.Client -> Microsoft.EntityFrameworkCore.Sqlite. See #492. -->
     <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageVersion Include="Refit" Version="8.0.0" />
-    <PackageVersion Include="System.Formats.Asn1" Version="10.0.9" />
     <PackageVersion Include="System.IO.Packaging" Version="10.0.9" />
-    <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.9" />
   </ItemGroup>
 </Project>

--- a/samples/todoapp/TodoApp.Uno/TodoApp.Uno/TodoApp.Uno.csproj
+++ b/samples/todoapp/TodoApp.Uno/TodoApp.Uno/TodoApp.Uno.csproj
@@ -74,10 +74,7 @@
     <PackageReference Include="CommunityToolkit.Datasync.Client" />
     <!-- Force the SQLitePCLRaw 3.x line to resolve NU1903 (GHSA-2m69-gcr7-jv3q) floated by CommunityToolkit.Datasync.Client -> Microsoft.EntityFrameworkCore.Sqlite. See #492. -->
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
-    <PackageReference Include="System.Formats.Asn1" />
     <PackageReference Include="System.IO.Packaging" />
-    <PackageReference Include="System.Private.Uri" />
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
   <ItemGroup>
     <Page Update="Views\TodoListPage.xaml">


### PR DESCRIPTION
## Summary

`samples/todoapp/TodoApp.Uno` restore emitted three `NU1510` warnings on every head (desktop, browserwasm, windows, android, ios-maccatalyst):

```
warning NU1510: PackageReference System.Formats.Asn1 will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
warning NU1510: PackageReference System.Private.Uri will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
warning NU1510: PackageReference System.Text.Json will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
```

`System.Formats.Asn1`, `System.Private.Uri`, and `System.Text.Json` were pinned as top-level `PackageReference`/`PackageVersion` entries since the Uno sample was first added. NuGet's package-pruning feature now considers these pins redundant on every head — the implicitly-resolved versions already satisfy the pins.

## Change

Removed the three redundant entries from:
- `samples/todoapp/TodoApp.Uno/Directory.Packages.props`
- `samples/todoapp/TodoApp.Uno/TodoApp.Uno/TodoApp.Uno.csproj`

`System.IO.Packaging` (never triggered NU1510) and `SQLitePCLRaw.bundle_e_sqlite3` (genuine NU1903 CVE floor, see #492) are left untouched, per the issue's guidance.

Note: contrary to the issue's guess, these pins predate the #492/#498-era NU1903 fixes — they were part of the original Uno sample scaffold (commit 9b9f9ec, Feb 2025) — but the fix (removal) is the same either way.

## Verification

- Local: `dotnet restore` + `dotnet build -f net10.0-desktop` on `TodoApp.Uno.csproj` — 0 NU1510 warnings (previously 3), build succeeded, only a pre-existing unrelated `Uno0001` warning remained.
- Local: `dotnet restore`/`dotnet build` on `Datasync.Toolkit.sln` (root) — 0 warnings, 0 errors (the Uno sample isn't referenced by the main solution).
- CI: dispatched the `Build Samples` workflow on the branch (https://github.com/adrianhall/CommunityToolkit-Datasync/actions/runs/29146039469) — all jobs succeeded, including all 5 `todoapp-uno` heads (android, ios-maccatalyst, windows, desktop, browserwasm). Confirmed 0 NU1510 occurrences in every job log (previously 3 each).

Fixes #540