### PR TITLE
fix: remove unused SQLite native asset warning in TodoApp.BlazorWasm.Client

### DIFF
--- a/samples/todoapp-blazor-wasm/TodoApp.BlazorWasm.Client/TodoApp.BlazorWasm.Client.csproj
+++ b/samples/todoapp-blazor-wasm/TodoApp.BlazorWasm.Client/TodoApp.BlazorWasm.Client.csproj
@@ -19,4 +19,18 @@
     <ProjectReference Include="..\TodoApp.BlazorWasm.Shared\TodoApp.BlazorWasm.Shared.csproj" />
   </ItemGroup>
 
+  <!--
+    CommunityToolkit.Datasync.Client depends unconditionally on Microsoft.EntityFrameworkCore.Sqlite,
+    which transitively adds a browser-wasm NativeFileReference for SourceGear.sqlite3's e_sqlite3.a
+    (via SQLitePCLRaw.bundle_e_sqlite3, pinned above only to resolve NU1903 - see #492). This app never
+    uses SQLite/OfflineDbContext, so the native asset is unused; remove it before the SDK's browser
+    workload check runs to avoid a benign, code-less "NativeFileReference is not empty..." warning
+    from WorkloadManifest.targets. See #523.
+  -->
+  <Target Name="RemoveUnusedSqliteNativeFileReference" BeforeTargets="_CheckBrowserWorkloadNeededButNotAvailable">
+    <ItemGroup>
+      <NativeFileReference Remove="@(NativeFileReference)" Condition="'%(Filename)%(Extension)' == 'e_sqlite3.a'" />
+    </ItemGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
## Summary

`samples/todoapp-blazor-wasm/TodoApp.BlazorWasm.Client` produced a benign, code-less MSBuild warning during a plain `dotnet build`:

```
WorkloadManifest.targets(124,5): warning : @(NativeFileReference) is not empty, but the native references
won't be linked in, because neither $(WasmBuildNative), nor $(RunAOTCompilation) are 'true'.
NativeFileReference=.../sourcegear.sqlite3/3.50.4.5/buildTransitive/net9.0/../../runtimes/browser-wasm/nativeassets/net9.0/e_sqlite3.a
```

## Root cause

`CommunityToolkit.Datasync.Client` depends unconditionally on `Microsoft.EntityFrameworkCore.Sqlite` (confirmed by inspecting `src/CommunityToolkit.Datasync.Client/CommunityToolkit.Datasync.Client.csproj`), which transitively resolves to `SourceGear.sqlite3` via `SQLitePCLRaw.bundle_e_sqlite3` (the version pinned in this project only to resolve NU1903 - see #492). `SourceGear.sqlite3`'s own `buildTransitive/net9.0/SourceGear.sqlite3.targets` unconditionally adds a `NativeFileReference` for `e_sqlite3.a` whenever `$(RuntimeIdentifier) == 'browser-wasm'` - independent of which `SQLitePCLRaw.bundle_e_sqlite3` version resolves, so pinning a narrower package wouldn't avoid it.

`TodoApp.BlazorWasm.Client` never uses SQLite/`OfflineDbContext` (verified: no references to `DbContext`, `Sqlite`, or `OfflineTable` anywhere in the project) - it only uses `CommunityToolkit.Datasync.Client` for online HTTP access - so this native asset is genuinely unused. The warning itself comes from the .NET SDK's own `_CheckBrowserWorkloadNeededButNotAvailable` target in `WorkloadManifest.targets`, which has no diagnostic code and therefore can't be suppressed via `NoWarn`.

## Fix

Remove the specific unused `e_sqlite3.a` `NativeFileReference` item from `TodoApp.BlazorWasm.Client.csproj` before the SDK's browser-workload check target runs:

```xml
<Target Name="RemoveUnusedSqliteNativeFileReference" BeforeTargets="_CheckBrowserWorkloadNeededButNotAvailable">
  <ItemGroup>
    <NativeFileReference Remove="@(NativeFileReference)" Condition="'%(Filename)%(Extension)' == 'e_sqlite3.a'" />
  </ItemGroup>
</Target>
```

This fixes the root cause (an asset that's provably never used) rather than just suppressing the symptom, and is scoped to this single sample project - no change to `CommunityToolkit.Datasync.Client` or any other sample.

## Testing

- `dotnet restore` + `dotnet build samples/todoapp-blazor-wasm/TodoApp.BlazorWasm.sln --configuration Debug` (matches `build-samples-todoapp-blazor-wasm.yml` exactly): negative control confirmed the warning appears twice on a clean build without this change, and zero times with it - `0 Warning(s), 0 Error(s)`.
- `dotnet restore` + `dotnet build Datasync.Toolkit.sln`: clean, `0 Warning(s), 0 Error(s)`.
- `dotnet test tests/CommunityToolkit.Datasync.Client.Test`: 1432/1432 passed (unaffected by this samples-only change, confirms no regression).
- Triggered the `Build Samples` GitHub Actions workflow on this branch in my fork: all 18 jobs succeeded, including `todoapp-blazor-wasm / build` and the `All samples built` aggregation job - https://github.com/adrianhall/CommunityToolkit-Datasync/actions/runs/29146333208

Fixes #523