### PR TITLE
fix: remove non-functional IsSwipeEnabled from TodoApp.Uno TodoListPage

### DIFF
--- a/samples/todoapp/TodoApp.Uno/TodoApp.Uno/Views/TodoListPage.xaml
+++ b/samples/todoapp/TodoApp.Uno/TodoApp.Uno/Views/TodoListPage.xaml
@@ -37,7 +37,6 @@
               Margin="10"
               ItemsSource="{x:Bind ViewModel.Items, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
               SelectionMode="None"
-              IsSwipeEnabled="True"
               ScrollViewer.VerticalScrollBarVisibility="Auto">
       <ListView.ItemTemplate>
         <DataTemplate>


### PR DESCRIPTION
## Summary

`TodoApp.Uno`'s `Views/TodoListPage.xaml` set `IsSwipeEnabled="True"` on the
`ListView`, but `ListViewBase.IsSwipeEnabled` is only implemented on the
native WinUI/Windows renderer in Uno Platform. This produced an `Uno0001`
build warning on the `android`, `browserwasm`, `desktop`, and
`ios-maccatalyst` heads (not `windows`).

## Root cause

This is a known Uno Platform limitation: `ListViewBase.IsSwipeEnabled` (and
the swipe-to-reveal-actions gesture it enables) only exists on the
WinUI/Windows renderer. Setting it is a no-op — and a compile-time warning —
on every Skia-based head. The sample doesn't implement any actual swipe
gesture (no `SwipeItems`, no `Uno.Toolkit.UI` `SwipeContainer`/`SwipeButton`),
so the attribute was dead configuration with no user-facing effect on any
platform, including Windows.

## Fix

Removed the `IsSwipeEnabled="True"` attribute from the `ListView` in
`Views/TodoListPage.xaml`. This matches option (1) from the issue
(remove the dead attribute) — the minimal fix, since:

- The equivalent `TodoApp.WinUI3/Views/TodoListPage.xaml` `ListView` never
  set this attribute either, so it isn't a cross-sample convention.
- No documentation (`docs/samples/todoapp/unoplatform.md`) references
  swipe-to-delete as an intentional teaching point for this sample.

## Verification

- `dotnet restore` / `dotnet build` against `Datasync.Toolkit.sln` (library
  and test projects, which don't include `TodoApp.Uno`) succeed unaffected.
- Dispatched `build-samples.yml` on this branch:
  https://github.com/adrianhall/CommunityToolkit-Datasync/actions/runs/29148063118
  — all jobs passed, including all `todoapp-uno` heads (`android`,
  `browserwasm`, `desktop`, `ios-maccatalyst`, `windows`).
- Confirmed the `Uno0001` warning no longer appears in the `todoapp-uno /
  android` job log (previously affected head).

Closes #537
