### PR TITLE
fix: use partial-property pattern for ObservableProperty in TodoApp.Uno TodoListViewModel

### DIFF
--- a/samples/todoapp/TodoApp.Uno/TodoApp.Uno/ViewModels/TodoListViewModel.cs
+++ b/samples/todoapp/TodoApp.Uno/TodoApp.Uno/ViewModels/TodoListViewModel.cs
@@ -18,13 +18,13 @@ public partial class TodoListViewModel(AppDbContext service) : ObservableRecipie
     internal event EventHandler<NotificationEventArgs> NotificationHandler;
 
     [ObservableProperty]
-    private bool isRefreshing;
+    public partial bool IsRefreshing { get; set; }
 
     [ObservableProperty]
-    private ConcurrentObservableCollection<TodoItemViewModel> items = [];
+    public partial ConcurrentObservableCollection<TodoItemViewModel> Items { get; set; } = [];
 
     [ObservableProperty]
-    private string title = string.Empty;
+    public partial string Title { get; set; } = string.Empty;
 
     [RelayCommand]
     public async Task AddItemAsync(CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary

`TodoApp.Uno/ViewModels/TodoListViewModel.cs` used the legacy `[ObservableProperty] private <type> field;` pattern from `CommunityToolkit.Mvvm`, which triggers `MVVMTK0045` warnings on the `net10.0-windows10.0.26100` head:

```
warning MVVMTK0045: The field ... using [ObservableProperty] will generate code that is not AOT compatible in WinRT scenarios (such as UWP XAML and WinUI 3 apps), and a partial property should be used instead ...
```

This converts `isRefreshing`, `items`, and `title` to the modern `[ObservableProperty] public partial <Type> Name { get; set; }` pattern, matching the style already used in `TodoApp.WinUI3/ViewModels/TodoListViewModel.cs`.

No other code changes are required — all internal usages within the file (and no other file in the sample) already reference the generated PascalCase properties (`IsRefreshing`, `Items`, `Title`) rather than the private backing fields.

## Verification

- Confirmed via `grep` across `samples/todoapp/TodoApp.Uno` that no code references the old lowercase field names.
- Dispatched `build-samples.yml` on the fork (`adrianhall/CommunityToolkit-Datasync`, branch `issues/538`): all 17 jobs passed, including `todoapp-uno / windows` — https://github.com/adrianhall/CommunityToolkit-Datasync/actions/runs/29148082198
- Confirmed the `MVVMTK0045` warning no longer appears in the `todoapp-uno / windows` job log.

Closes #538
