### PR TITLE
fix: suppress WASM0001 sqlite3_config/db_config varargs warnings on TodoApp.Uno browserwasm

### DIFF
--- a/docs/samples/todoapp/unoplatform.md
+++ b/docs/samples/todoapp/unoplatform.md
@@ -18,6 +18,14 @@ If you bump into issues at this point, ensure you can properly develop and run U
 !!! info Tested platforms
     The TodoApp.Uno sample is known to work on Android and Desktop.  We have not tested on other platforms.
 
+!!! info WASM0001 warning on the browserwasm head
+    When building the `browserwasm` head, you may see a `WASM0001` warning about native varargs
+    functions (`sqlite3_config`/`sqlite3_db_config`) in the bundled SQLite provider.  This is
+    harmless diagnostic noise from the WebAssembly SDK's native-interop check - the sample's
+    actual SQLite usage never calls those functions directly - and is already suppressed for
+    this sample's `.csproj`.  See the [Blazor WASM support](../../in-depth/client/advanced/blazor-wasm.md#suppress-the-wasm0001-warning)
+    page for more detail on why this warning occurs and how to suppress it in your own project.
+
 ## Deploy a datasync server to Azure
 
 Before you begin adjusting the application for offline usage, you must [deploy a datasync service](./server.md).  Make a note of the URI of the service before continuing.

--- a/samples/todoapp/TodoApp.Uno/TodoApp.Uno/TodoApp.Uno.csproj
+++ b/samples/todoapp/TodoApp.Uno/TodoApp.Uno/TodoApp.Uno.csproj
@@ -66,6 +66,20 @@
         $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'
       ">$(MSBuildWarningsAsMessages);MT7156</MSBuildWarningsAsMessages>
 
+    <!--
+      e_sqlite3 (bundled via SQLitePCLRaw.bundle_e_sqlite3, pinned for #492) exposes variadic
+      (varargs) native functions (sqlite3_config/sqlite3_db_config). The WebAssembly SDK's
+      build-time native-interop check flags every fixed-arity P/Invoke overload SQLitePCLRaw
+      ships to work around this (sqlite3_config_none, sqlite3_config_int, etc.) as WASM0001,
+      even though this sample's actual SQLite usage (in-memory EF Core CRUD via AppDbContext)
+      never calls sqlite3_config/sqlite3_db_config directly. This is diagnostic-only noise -
+      WASM0001 is a standard MSBuild task warning code (emitted via TaskLoggingHelper.LogWarning
+      in dotnet/runtime's WasmAppBuilder), so it honors NoWarn like any other build warning.
+      Same documented, NoWarn-suppressible pattern as
+      docs/in-depth/client/advanced/blazor-wasm.md. See #543.
+    -->
+    <NoWarn Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'browserwasm'">$(NoWarn);WASM0001</NoWarn>
+
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Assets\AddItem.png" />


### PR DESCRIPTION
## Summary

Fixes #543.

The `browserwasm` head of `TodoApp.Uno` emits a block of `WASM0001` warnings about unsupported native varargs functions in the bundled SQLite provider:

```
warning WASM0001: Found a native function (sqlite3_config) with varargs in e_sqlite3. Calling such functions is not supported, and will fail at runtime. Managed DllImports:
warning WASM0001:     System.Int32 sqlite3_config_none(System.Int32) (in [SQLitePCLRaw.provider.e_sqlite3] SQLitePCL.SQLite3Provider_e_sqlite3+NativeMethods)
...
warning WASM0001: Found a native function (sqlite3_db_config) with varargs in e_sqlite3. Calling such functions is not supported, and will fail at runtime. Managed DllImports:
```

CI run that surfaced this: https://github.com/CommunityToolkit/Datasync/actions/runs/29093946725 (`todoapp-uno / browserwasm` job)

## Root cause

`e_sqlite3`'s native `sqlite3_config`/`sqlite3_db_config` C functions are variadic (varargs), which the WebAssembly toolchain's managed-to-native interop cannot support. `SQLitePCLRaw.provider.e_sqlite3` ships several fixed-arity P/Invoke overloads (`sqlite3_config_none`, `sqlite3_config_int`, `sqlite3_config_log`, etc.) to work around this for the specific configuration calls SQLitePCLRaw itself needs — the WebAssembly SDK's build-time native-interop check flags all of them anyway as a blanket "any varargs-shaped native symbol is risky" warning, even though this sample's actual SQLite usage (`AppDbContext` configured with `UseSqlite` against an in-memory connection in `App.xaml.cs`) never calls `sqlite3_config`/`sqlite3_db_config` directly.

## Why suppress rather than fix the code

`WASM0001` is emitted via `TaskLoggingHelper.LogWarning(..., warningCode: "WASM0001", ...)` in `dotnet/runtime`'s `WasmAppBuilder` (`PInvokeTableGenerator.cs` → `LogAdapter.Warning`) — the standard MSBuild task-warning overload, which honors `$(NoWarn)`/warnings-as-errors filtering like any other build warning (`CS*`, `NETSDK*`, etc.). This repo already documents and uses exactly this suppression for the same warning on the Blazor WASM sample, in `docs/in-depth/client/advanced/blazor-wasm.md` (added in #394):

```xml
<PropertyGroup>
    <NoWarn>$(NoWarn);WASM0001</NoWarn>
</PropertyGroup>
```

Unlike the Blazor WASM sample — which never actually uses SQLite and instead removes the unused native asset before the workload check runs (see #523) — `TodoApp.Uno` genuinely configures EF Core with the SQLite provider on every head, including `browserwasm`, so that trick doesn't apply here. Suppression is the correct fix, matching the issue's own root-cause analysis.

## Changes

- `samples/todoapp/TodoApp.Uno/TodoApp.Uno/TodoApp.Uno.csproj` — added `<NoWarn Condition="...GetTargetPlatformIdentifier(...) == 'browserwasm'">$(NoWarn);WASM0001</NoWarn>`, scoped to the `browserwasm` TFM only (the only head that runs the WebAssembly SDK's native-interop check), following the same `GetTargetPlatformIdentifier`-conditional pattern already used in this file for `SuppressTrimAnalysisWarnings` (see #521/#534).
- `docs/samples/todoapp/unoplatform.md` — added a short callout about the `WASM0001` warning on the `browserwasm` head, pointing readers at the more detailed `blazor-wasm.md` explanation for why it occurs and how to suppress it in their own projects.

## Testing

- `dotnet restore` / `dotnet build --configuration Debug` on `Datasync.Toolkit.sln` — succeeded, 0 warnings / 0 errors. (This solution doesn't include the edited sample project, confirming no impact on the core library.)
- `dotnet test Datasync.Toolkit.sln --no-build --configuration Debug` — `CommunityToolkit.Datasync.Client.Test`: 1432/1432 passed, plus all non-container-dependent server test suites passed 100%. `Server.Test`/`Server.MongoDB.Test`/`Server.EntityFrameworkCore.Test` had pre-existing, environment-only failures (no local Docker daemon; those suites depend on TestContainers) — unrelated to this change, matching the precedent noted in #531.
- Triggered `build-samples.yml` on this branch via `workflow_dispatch`: [run 29150192782](https://github.com/adrianhall/CommunityToolkit-Datasync/actions/runs/29150192782) — all jobs succeeded, including `todoapp-uno / browserwasm`, which now reports `0 Warning(s)` (previously the block of `WASM0001` warnings shown above), and the `all-samples-built` aggregation gate.

## Related

- #521 / #531 / #534 — same class of fix (suppressing diagnostic-only build warnings that are harmless in this CI pipeline's build-only, never-published sample builds), applied earlier to trim-analysis warnings on the Avalonia/MAUI/Uno samples.
- #394 — introduced the `WASM0001` suppression pattern this PR reuses, for the Blazor WASM sample.
- #492 / #523 — prior `SQLitePCLRaw`/native-asset handling this warning builds on.
