### PR TITLE
fix: suppress MT7156 duplicate BundleResource warnings on TodoApp.Uno ios/maccatalyst

### DIFF
--- a/samples/todoapp/TodoApp.Uno/TodoApp.Uno/TodoApp.Uno.csproj
+++ b/samples/todoapp/TodoApp.Uno/TodoApp.Uno/TodoApp.Uno.csproj
@@ -52,6 +52,20 @@
         $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'browserwasm'
       ">true</SuppressTrimAnalysisWarnings>
 
+    <!--
+      MT7156: Uno.Resizetizer (unoresizetizer) rasterizes each SVG-sourced asset
+      (Assets/Icons/icon_foreground.svg, Assets/Images/back.svg, Assets/Splash/splash_screen.svg)
+      into both an unscaled base PNG and an explicit "scale-100" variant. On ios/maccatalyst these
+      collapse to the same BundleResource LogicalName (Apple bundling treats unscaled and "1x" as
+      identical), so one copy is silently dropped - benign, expected Resizetizer output on these
+      TFMs, not a duplicate-inclusion bug in this project's Assets/UnoIcon/UnoSplashScreen wiring.
+      See #541.
+    -->
+    <MSBuildWarningsAsMessages Condition="
+        $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' OR
+        $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'
+      ">$(MSBuildWarningsAsMessages);MT7156</MSBuildWarningsAsMessages>
+
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Assets\AddItem.png" />


### PR DESCRIPTION
## Summary

The `ios-maccatalyst` head of `TodoApp.Uno` emits `MT7156` warnings about duplicate `BundleResource` items during build:

```
warning MT7156: The BundleResource item '.../unoresizetizer/r/Assets/Icons/icon_foreground.png' was ignored, because there's another item with the same LogicalName ('Assets/Icons/icon_foreground.png')
warning MT7156: The BundleResource item '.../unoresizetizer/r/Assets/Images/back.png' was ignored, because there's another item with the same LogicalName ('Assets/Images/back.png')
warning MT7156: The BundleResource item '.../unoresizetizer/r/splash_screen.png' was ignored, because there's another item with the same LogicalName ('splash_screen.png')
```

Fixes #541

## Root cause

`Uno.Resizetizer` (`unoresizetizer`) rasterizes each SVG-sourced asset (`Assets/Icons/icon_foreground.svg`, `Assets/Images/back.svg`, `Assets/Splash/splash_screen.svg`) into both an unscaled base PNG and an explicit `scale-100` variant. On `ios`/`maccatalyst`, both collapse to the same `BundleResource` `LogicalName`, because Apple's bundling convention treats an unscaled asset and its `1x`/`scale-100` counterpart as identical — so one copy is silently dropped. The build still succeeds and the icon/splash render correctly; this is a warning about redundant bundling, not a missing or broken asset.

This is **not** a duplicate-inclusion bug in this project's `Assets` wiring: `TodoApp.Uno.csproj` has no explicit `UnoIcon`/`UnoSplashScreen`/`UnoImage` items — Uno.Sdk's Single Project convention auto-wires `Assets/Icons/*.svg`, `Assets/Splash/*.svg`, and `Assets/Images/*.svg` into the resizetizer pipeline implicitly, and this dual base+scale-100 emission on Apple TFMs is inherent `Uno.Resizetizer` output, confirmed by inspecting the CI job log directly (both `net10.0-ios` and `net10.0-maccatalyst` TargetFrameworks affected, for exactly the same three assets).

## Why suppress rather than change the resource pipeline

This repo's CI only ever runs `dotnet build` for `TodoApp.Uno` (never publishes/packages the app), so the redundant bundling has no functional consequence in this pipeline. Attempting to reconfigure the `UnoImage`/`UnoIcon`/`UnoSplashScreen` pipeline to avoid the redundant `scale-100` copy would require visual verification on an iOS/macCatalyst simulator (no Xcode available in this sandbox) and risks inadvertently affecting the Android/Windows heads, which legitimately need multiple scale variants from the same SVG sources.

Same fix pattern as #531/#548 (`SuppressTrimAnalysisWarnings` for the equivalent IL2026/IL2104 trim-analyzer noise): suppress the specific, confirmed-benign warning code via a precisely scoped MSBuild property, with a comment documenting the root cause.

## Changes

`samples/todoapp/TodoApp.Uno/TodoApp.Uno/TodoApp.Uno.csproj`:

- Added `MSBuildWarningsAsMessages` for warning code `MT7156`, scoped to `ios`/`maccatalyst` only via the same `$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))` conditional pattern already used for `SuppressTrimAnalysisWarnings` in this file.
- `android`/`desktop`/`browserwasm`/`windows` are intentionally left untouched — the CI job log confirms `MT7156` (an Apple-toolchain-specific code) only ever appears on `ios`/`maccatalyst`.

## Verification

- **Negative control via CI**: compared the `ios-maccatalyst` job log from the current `main` HEAD (`ddd8c04`, before this fix) against this branch's CI run.
  - Before: `main`'s `ios-maccatalyst` job log shows **20** `MT7156` occurrences.
  - After: this branch's `ios-maccatalyst` job log shows **0** `MT7156` occurrences, and the job still succeeds.
  - Both runs show the same **36** `IL2026` occurrences (a separate, pre-existing trim-analyzer finding from #534/#548, out of scope here and unaffected by this change either way) — confirming this fix is scoped precisely to `MT7156` and doesn't mask or interact with anything else.
- `net10.0-desktop`: `dotnet restore`/`build` clean, no workload required — confirms the change doesn't regress unrelated heads.
- `net10.0-browserwasm`: could not verify locally (installing the `wasm-tools` workload requires elevated privileges in this sandbox, same limitation noted in #548); covered by CI instead (job succeeded, unaffected).
- Root `Datasync.Toolkit.sln` (unaffected by this change, `TodoApp.Uno` isn't part of it): restores/builds clean (`0 Warning(s)`, `0 Error(s)`). `CommunityToolkit.Datasync.Client.Test` passes 1432/1432.
- CI: dispatched `build-samples.yml` on the fork (`adrianhall/CommunityToolkit-Datasync`, ref `issues/541`) — all 17 jobs succeeded, including `todoapp-uno / ios-maccatalyst` and the `All samples built` aggregation gate. Run: https://github.com/adrianhall/CommunityToolkit-Datasync/actions/runs/29150182538

Not verified locally (relying on CI, same limitation noted in #531/#548):
- `ios`/`maccatalyst`: require a full Xcode install (only Command Line Tools available here).
- `android`: requires the Android SDK/workload.
- `windows`: requires a Windows runner.
